### PR TITLE
Refactor `RemoteAPI` to not depends on the node implementation type

### DIFF
--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -95,12 +95,12 @@ public final class RemoteAPI (API, Implementation : API) : API
 
     ***************************************************************************/
 
-    private static void spawned (CtorParams...) (CtorParams args)
+    private static void spawned (CtorParams...) (CtorParams cargs)
     {
         import std.format;
 
         bool terminated = false;
-        scope node = new Implementation(args);
+        scope node = new Implementation(cargs);
 
         scope handler = (Command cmd) {
             SWITCH:

--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -1,8 +1,8 @@
 /*******************************************************************************
 
-    Provides utilities to moch an async REST node on the network
+    Provides utilities to mock an async REST node in unittests
 
-    Using `vibe.web.rest` allow to cleanly separate business code
+    Using `vibe.web.rest` allows to cleanly separate business code
     from network code, as implementing an interface is all that's
     needed to create a server.
 


### PR DESCRIPTION
This is a breaking change, but the translation from the old to the new style is rather mechanic, as seen in the unittests. Also there's no user but BPFK that I know of.