### PR TITLE
Silence warning when composite type is empty

### DIFF
--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -101,6 +101,8 @@ private struct Response
 /// Vibe.d might emit a pragma(msg) when T.length == 0
 private struct ArgWrapper (T...)
 {
+    static if (T.length == 0)
+        size_t dummy;
     T args;
 }
 


### PR DESCRIPTION
As you can see from the comment, it was always intended to do this...