### PR TITLE
Implement a VirtualClock, and use it in RemoteAPI

### DIFF
--- a/source/geod24/VirtualClock.d
+++ b/source/geod24/VirtualClock.d
@@ -1,0 +1,126 @@
+/*******************************************************************************
+
+    Contains an implementation of a virtual clock. The clock by default follows
+    the monotonic clock, but may be paused, resumed, and can even time-travel
+    by settings its time offset.
+
+    Author:         Andrej Mitrovic
+    License:        MIT (See LICENSE.txt)
+    Copyright:      Copyright (c) 2018-2019 Mathias Lang. All rights reserved.
+
+*******************************************************************************/
+
+module geod24.VirtualClock;
+
+import std.datetime.stopwatch;
+
+import core.time;
+
+/// Ditto
+public class VirtualClock
+{
+    /// Whether the clock has been paused
+    private bool paused;
+
+    /// Stopwatch used to track progress of time
+    private StopWatch sw;
+
+    /// The initial start time of the clock
+    private const MonoTime start_time;
+
+
+    /***************************************************************************
+
+        Constructor
+
+        The virtual clock begins keeping track of time right away.
+
+    ***************************************************************************/
+
+    public this () nothrow @nogc @safe
+    {
+        this.start_time = MonoTime.currTime();
+        this.sw = StopWatch(AutoStart.yes);
+    }
+
+    /***************************************************************************
+
+        Returns:
+            the current virtual time
+
+    ***************************************************************************/
+
+    public MonoTime currTime () nothrow @nogc @safe
+    {
+        return this.start_time + this.sw.peek();
+    }
+
+    /***************************************************************************
+
+        Pauses the clock.
+
+    ***************************************************************************/
+
+    public void pause () nothrow @nogc @safe
+    {
+        this.paused = true;
+        this.sw.stop();
+    }
+
+    /***************************************************************************
+
+        Resume the clock from the last paused time.
+        If the clock was not paused it's a no-op.
+
+    ***************************************************************************/
+
+    public void resume () nothrow @nogc @safe
+    {
+        if (!this.paused)
+            return;
+
+        this.sw.start();
+        this.paused = false;
+    }
+
+    /***************************************************************************
+
+        Add a time offset to the virtual clock.
+
+        Note: the offset may be negative, to "time-travel" into the past
+
+    ***************************************************************************/
+
+    public void addTimeOffset (Duration offset) nothrow @nogc @safe
+    {
+        this.sw.setTimeElapsed(this.sw.peek() + offset);
+    }
+}
+
+/// Ditto
+unittest
+{
+    import core.thread;
+    auto vc = new VirtualClock();
+    vc.pause();
+    auto pause_time = vc.currTime();
+
+    Thread.sleep(10.msecs);
+    assert(vc.currTime() == pause_time);
+
+    vc.resume();
+    vc.resume();  // no-op
+    Thread.sleep(10.msecs);
+    assert(vc.currTime() > pause_time);
+
+    vc.pause();
+    auto new_time = vc.currTime();
+
+    // adds a negative offset
+    vc.addTimeOffset(-(new_time - pause_time));
+    assert(vc.currTime() == pause_time);
+
+    // adds a positive offset
+    vc.addTimeOffset(50.msecs);
+    assert(vc.currTime() == pause_time + 50.msecs);
+}


### PR DESCRIPTION
I went through several different designs, trying to make things work. I tried out Stellar's VirtualClock implementation, but it doesn't seem like a model that can fit to our use-case (we have per-node threads, they have AFAICT only one main and one worker thread and that's it).

The previous designs based on Stellar's VirtualClock were complex and had flaws.

So instead, I've implemented a much simpler design. I thought about what we needed, and then designed around that:

- We need a way to "pause" time for a node. This is not the same as making a node unresponsive via `ctrl.sleep`, because in the `ctrl.sleep` scenario when the node wakes up its monotonic clock would have still made progress, and any events which were waiting will suddenly start firing.

- We need a way to resume paused time (obviously).

- We need a way to time-travel. This is especially useful in some scenarios: if we expect a node to generate some data (reach consensus every 10 minutes), it would be great to not have to wait for 10 minutes to physically pass.

- Time travel also allows us to test time drifting behavior.

-----