### PR TITLE
Remove ability to link threads, make 'Scheduler' private

### DIFF
--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -1370,14 +1370,7 @@ private:
     size_t m_pos;
 }
 
-/**
- * Sets the Scheduler behavior within the program.
- *
- * This variable sets the Scheduler behavior within this program.  Typically,
- * when setting a Scheduler, scheduler.start() should be called in main.  This
- * routine will not return until program execution is complete.
- */
-__gshared Scheduler scheduler;
+private __gshared Scheduler scheduler;
 
 /**
  * This function will call scheduler.yield() or Fiber.yield(), as appropriate.


### PR DESCRIPTION
Looks like there was a bug in the links implementation: Even if `linked` was `false`, it would be added to the AA, which means it would be iterated on when doing `foreach (tid; links.keys)`