### PR TITLE
Remove Scheduler interface, make 'receive' rely less on global state

### DIFF
--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -471,7 +471,7 @@ public final class RemoteAPI (API) : API
                 bool terminated = false;
                 while (!terminated)
                 {
-                    C.receiveTimeout(10.msecs,
+                    C.receiveTimeout(C.thisTid(), 10.msecs,
                         (C.OwnerTerminated e) { terminated = true; },
                         (ShutdownCommand e) {
                             terminated = true;
@@ -745,7 +745,7 @@ public final class RemoteAPI (API) : API
                             runTask(() {
                                 while (!terminated)
                                 {
-                                    C.receiveTimeout(10.msecs,
+                                    C.receiveTimeout(C.thisTid(), 10.msecs,
                                         (Response res) {
                                             scheduler.pending = res;
                                             scheduler.waiting[res.id].c.notify();
@@ -895,9 +895,10 @@ unittest
         geod24.concurrency.send(parent, 42);
     }
 
-    auto testerFiber = geod24.concurrency.spawn(&testFunc, geod24.concurrency.thisTid);
+    auto self = geod24.concurrency.thisTid();
+    auto testerFiber = geod24.concurrency.spawn(&testFunc, self);
     // Make sure our main thread terminates after everyone else
-    geod24.concurrency.receiveOnly!int();
+    geod24.concurrency.receiveOnly!int(self);
 }
 
 /// This network have different types of nodes in it

--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -406,7 +406,7 @@ public final class RemoteAPI (API) : API
 
     ***************************************************************************/
 
-    private static void spawned (Implementation) (CtorParams!Implementation cargs)
+    private static void spawned (Implementation) (C.Tid self, CtorParams!Implementation cargs)
     {
         import std.datetime.systime : Clock, SysTime;
         import std.algorithm : each;
@@ -876,7 +876,7 @@ unittest
     auto node1 = factory("normal", 1);
     auto node2 = factory("byzantine", 2);
 
-    static void testFunc(geod24.concurrency.Tid parent)
+    static void testFunc(geod24.concurrency.Tid self, geod24.concurrency.Tid parent)
     {
         auto node1 = factory("this does not matter", 1);
         auto node2 = factory("neither does this", 2);

--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -506,21 +506,6 @@ if (isSpawnable!(F, T))
     assert(self.receiveOnly!string == "This is so great!");
 }
 
-@system unittest
-{
-    import core.thread : thread_joinAll;
-
-    __gshared string receivedMessage;
-    static void f1(Tid self, string msg)
-    {
-        receivedMessage = msg;
-    }
-
-    auto tid1 = spawn(&f1, "Hello World");
-    thread_joinAll;
-    assert(receivedMessage == "Hello World");
-}
-
 /*
  *
  */

--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -601,7 +601,7 @@ if (isSpawnable!(F, T))
 void send(T...)(Tid tid, T vals)
 {
     static assert(!hasLocalAliasing!(T), "Aliases to mutable thread-local data not allowed.");
-    _send(tid, vals);
+    _send(MsgType.standard, tid, vals);
 }
 
 /**
@@ -615,14 +615,6 @@ void prioritySend(T...)(Tid tid, T vals)
 {
     static assert(!hasLocalAliasing!(T), "Aliases to mutable thread-local data not allowed.");
     _send(MsgType.priority, tid, vals);
-}
-
-/*
- * ditto
- */
-private void _send(T...)(Tid tid, T vals)
-{
-    _send(MsgType.standard, tid, vals);
 }
 
 /*


### PR DESCRIPTION
A step further into removing global steps and having CSP instead of Actor model.