### PR TITLE
Remove usage of globals in concurrency

### DIFF
--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -217,6 +217,11 @@ private
 
     @property ref ThreadInfo thisInfo() nothrow
     {
+        auto t = cast(InfoThread)Thread.getThis();
+
+        if (t !is null)
+            return t.info;
+
         return ThreadInfo.thisInfo;
     }
 }
@@ -485,7 +490,7 @@ if (isSpawnable!(F, T))
     }
 
     // TODO: MessageList and &exec should be shared.
-    auto t = new Thread(&exec);
+    auto t = new InfoThread(&exec);
     t.start();
     return spawnTid;
 }
@@ -994,6 +999,12 @@ class FiberScheduler
 
         if (f !is null)
             return f.info;
+
+        auto t = cast(InfoThread)Thread.getThis();
+
+        if (t !is null)
+            return t.info;
+
         return ThreadInfo.thisInfo;
     }
 

--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -849,6 +849,51 @@ struct ThreadInfo
     }
 }
 
+
+/***************************************************************************
+
+    Thread with ThreadInfo,
+    This is implemented to avoid using global variables.
+
+***************************************************************************/
+
+public class InfoThread : Thread
+{
+    public ThreadInfo info;
+
+    /***************************************************************************
+
+        Initializes a thread object which is associated with a static
+
+        Params:
+            fn = The thread function.
+            sz = The stack size for this thread.
+
+    ***************************************************************************/
+
+    this (void function() fn, size_t sz = 0) @safe pure nothrow @nogc
+    {
+        super(fn, sz);
+    }
+
+
+    /***************************************************************************
+
+        Initializes a thread object which is associated with a dynamic
+
+        Params:
+            dg = The thread function.
+            sz = The stack size for this thread.
+
+    ***************************************************************************/
+
+    this (void delegate() dg, size_t sz = 0) @safe pure nothrow @nogc
+    {
+        super(dg, sz);
+    }
+}
+
+
 /**
  * An example Scheduler using kernel threads.
  *


### PR DESCRIPTION
When calling function `thisInfo`, a global variable is created for each thread.
I made an `InfoThread` that inherited Thread.
It has a `ThreadInfo` inside. 
Therefore, if  `InfoThread` is used, the use of global variables can be reduced.
Issues is #39 Remove usage of globals in concurrency