### PR TITLE
Implement buffered channels. 

### DIFF
--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -824,6 +824,8 @@ struct ThreadInfo
     Tid ident;
     Tid owner;
 
+    public FiberScheduler scheduler;
+
     /**
      * Gets a thread-local instance of ThreadInfo.
      *
@@ -851,6 +853,30 @@ struct ThreadInfo
         if (owner != Tid.init)
             _send(MsgType.linkDead, owner, ident);
     }
+}
+
+
+/***************************************************************************
+
+    Getter of FiberScheduler assigned to a called thread.
+
+***************************************************************************/
+
+public @property FiberScheduler thisScheduler () nothrow
+{
+    return thisInfo.scheduler;
+}
+
+
+/***************************************************************************
+
+    Setter of FiberScheduler assigned to a called thread.
+
+***************************************************************************/
+
+public @property void thisScheduler (FiberScheduler value) nothrow
+{
+    thisInfo.scheduler = value;
 }
 
 


### PR DESCRIPTION
This is similar to `Go-Lang channel`
It has one buffer.
It does not block when writing. However, when reading, it blocks if there is no data.

There are two kinds of fiber(thread). One reads, and one writes.

**Buffered channel**
When the write-fiber(thread) is working,
it puts the message in the queue.
When the read-fiber(thread) is working,
take the message out of the queue and take it.
If there are no messages in the queue, wait for write-fiber(thread) to put
the messages in the queue.

The issue is #40 Implement buffered channels