### PR TITLE
Implement unbuffered channels

### DIFF
--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -824,6 +824,8 @@ struct ThreadInfo
     Tid ident;
     Tid owner;
 
+    public FiberScheduler scheduler;
+
     /**
      * Gets a thread-local instance of ThreadInfo.
      *
@@ -851,6 +853,30 @@ struct ThreadInfo
         if (owner != Tid.init)
             _send(MsgType.linkDead, owner, ident);
     }
+}
+
+
+/***************************************************************************
+
+    Getter of FiberScheduler assigned to a called thread.
+
+***************************************************************************/
+
+public @property FiberScheduler thisScheduler () nothrow
+{
+    return thisInfo.scheduler;
+}
+
+
+/***************************************************************************
+
+    Setter of FiberScheduler assigned to a called thread.
+
+***************************************************************************/
+
+public @property void thisScheduler (FiberScheduler value) nothrow
+{
+    thisInfo.scheduler = value;
 }
 
 


### PR DESCRIPTION
I Implemented the default channel semantic of Go, unbuffered channels that provide direct hands off semantics.

There are two kinds of fiber(thread). One reads, and one writes.

**Unbuffered channel**

When the write-fiber(thread) is working, 
it sends the data to the read-fiber(thread) if it already exists.
Otherwise, the write-fiber(thread) waits for the read-fiber(thread) to come in.

When read-fiber(thread) works, 
it receives data from the write-fiber(thread) if it already exists.
Otherwise, the read-fiber(thread) waits for the write-fiber(thread) to come in.

The issue is #41 Implement unbuffered channels