### PR TITLE
Add test codes for message passing between thread and thread, thread and fiber, fiber and fiber.

### DIFF
--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -824,6 +824,8 @@ struct ThreadInfo
     Tid ident;
     Tid owner;
 
+    public FiberScheduler scheduler;
+
     /**
      * Gets a thread-local instance of ThreadInfo.
      *
@@ -851,6 +853,30 @@ struct ThreadInfo
         if (owner != Tid.init)
             _send(MsgType.linkDead, owner, ident);
     }
+}
+
+
+/***************************************************************************
+
+    Getter of FiberScheduler assigned to a called thread.
+
+***************************************************************************/
+
+public @property FiberScheduler thisScheduler () nothrow
+{
+    return thisInfo.scheduler;
+}
+
+
+/***************************************************************************
+
+    Setter of FiberScheduler assigned to a called thread.
+
+***************************************************************************/
+
+public @property void thisScheduler (FiberScheduler value) nothrow
+{
+    thisInfo.scheduler = value;
 }
 
 

--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -2040,3 +2040,331 @@ unittest
 
     assert(results == ["+ Ping", "* Ping", "+ Ping", "* Ping", "+ Ping", "* Ping", "* Boom"]);
 }
+
+/// spawn thread
+version (unittest) void spawnThread (void delegate() op)
+{
+    auto t1 = new InfoThread({
+        thisScheduler = new FiberScheduler();
+        op();
+    });
+    t1.start();
+}
+
+/// Min Thread -> [ channel1 ] -> Thread1 -> [ channel2 ] -> Min Thread
+unittest
+{
+    auto channel1 = new Channel!int;
+    auto channel2 = new Channel!int;
+
+    // Thread1
+    spawnThread({
+        int msg = channel1.receive();
+        channel2.send(msg*msg);
+    });
+
+    // Main Thread1
+    channel1.send(2);
+    assert(channel2.receive() == 4);
+}
+
+
+/// Min Thread -> [ channel1 ] -> Fiber1 in Thread1 -> [ channel2 ] -> Min Thread
+unittest
+{
+    auto channel1 = new Channel!int;
+    auto channel2 = new Channel!int;
+
+    // Thread1
+    spawnThread({
+        // Fiber1
+        thisScheduler.start({
+            int msg = channel1.receive();
+            channel2.send(msg*msg);
+        });
+    });
+
+    // Main Thread
+    channel1.send(2);
+    assert(channel2.receive() == 4);
+}
+
+/// Fiber in Min Thread -> [ channel1 ] -> Fiber1 in Thread1 -> [ channel2 ] -> Fiber in Min Thread
+unittest
+{
+    auto channel1 = new Channel!int;
+    auto channel2 = new Channel!int;
+    int result;
+
+    // Thread1
+    spawnThread({
+        // Fiber1
+        thisScheduler.start({
+            int msg = channel1.receive();
+            channel2.send(msg*msg);
+        });
+    });
+
+    // Main Thread
+    thisScheduler = new FiberScheduler();
+    thisScheduler.start({
+        channel1.send(2);
+        result = channel2.receive();
+    });
+    assert(result == 4);
+}
+
+/// Fiber1 -> [ channel2 ] -> Fiber2 -> [ channel1 ] -> Fiber1
+unittest
+{
+    auto channel1 = new Channel!int;
+    auto channel2 = new Channel!int;
+    int result;
+
+    Mutex mutex = new Mutex;
+    Condition condition = new Condition(mutex);
+
+    // Thread1
+    spawnThread({
+        scope scheduler = thisScheduler;
+        scheduler.start({
+            //  Fiber1
+            scheduler.spawn({
+                channel2.send(2);
+                result = channel1.receive();
+                synchronized (mutex)
+                {
+                    condition.notify;
+                }
+            });
+            //  Fiber2
+            scheduler.spawn({
+                int msg = channel2.receive();
+                channel1.send(msg*msg);
+            });
+        });
+    });
+
+    synchronized (mutex)
+    {
+        condition.wait(1000.msecs);
+    }
+
+    assert(result == 4);
+}
+
+
+/// Fiber1 in Thread1 -> [ channel2 ] -> Fiber2 in Thread2 -> [ channel1 ] -> Fiber1 in Thread1
+unittest
+{
+    auto channel1 = new Channel!int;
+    auto channel2 = new Channel!int;
+    int result;
+
+    Mutex mutex = new Mutex;
+    Condition condition = new Condition(mutex);
+
+    // Thread1
+    spawnThread({
+        // Fiber1
+        thisScheduler.start({
+            channel2.send(2);
+            result = channel1.receive();
+            synchronized (mutex)
+            {
+                condition.notify;
+            }
+        });
+    });
+
+    // Thread2
+    spawnThread({
+        // Fiber2
+        thisScheduler.start({
+            int msg = channel2.receive();
+            channel1.send(msg*msg);
+        });
+    });
+
+    synchronized (mutex)
+    {
+        condition.wait(1000.msecs);
+    }
+    assert(result == 4);
+}
+
+
+/// Thread1 -> [ channel2 ] -> Thread2 -> [ channel1 ] -> Thread1
+unittest
+{
+    auto channel1 = new Channel!int;
+    auto channel2 = new Channel!int;
+    int result;
+
+    Mutex mutex = new Mutex;
+    Condition condition = new Condition(mutex);
+
+    // Thread1
+    spawnThread({
+        channel2.send(2);
+        result = channel1.receive();
+        synchronized (mutex)
+        {
+            condition.notify;
+        }
+    });
+
+    // Thread2
+    spawnThread({
+        int msg = channel2.receive();
+        channel1.send(msg*msg);
+    });
+
+    synchronized (mutex)
+    {
+        condition.wait(3000.msecs);
+    }
+
+    assert(result == 4);
+}
+
+
+/// Thread1 -> [ channel2 ] -> Fiber1 in Thread 2 -> [ channel1 ] -> Thread1
+unittest
+{
+    auto channel1 = new Channel!int;
+    auto channel2 = new Channel!int;
+    int result;
+
+    Mutex mutex = new Mutex;
+    Condition condition = new Condition(mutex);
+
+    // Thread1
+    spawnThread({
+        channel2.send(2);
+        result = channel1.receive();
+        synchronized (mutex)
+        {
+            condition.notify;
+        }
+    });
+
+    // Thread2
+    spawnThread({
+        // Fiber1
+        thisScheduler.start({
+            int msg = channel2.receive();
+            channel1.send(msg*msg);
+        });
+    });
+
+    synchronized (mutex)
+    {
+        condition.wait(1000.msecs);
+    }
+    assert(result == 4);
+}
+
+
+// If the queue size is 0, it will block when it is sent and received on the same thread.
+unittest
+{
+    auto channel1 = new Channel!int(0);
+    auto channel2 = new Channel!int(1);
+    int result = 0;
+
+    Mutex mutex = new Mutex;
+    Condition condition = new Condition(mutex);
+
+    // Thread1 - It'll be tangled.
+    spawnThread({
+        channel1.send(2);
+        result = channel1.receive();
+        synchronized (mutex)
+        {
+            condition.notify;
+        }
+    });
+
+    synchronized (mutex)
+    {
+        condition.wait(1000.msecs);
+    }
+    assert(result == 0);
+
+    // Thread2 - Unravel a tangle
+    spawnThread({
+        result = channel1.receive();
+        channel1.send(2);
+    });
+
+    synchronized (mutex)
+    {
+        condition.wait(1000.msecs);
+    }
+    assert(result == 2);
+
+    result = 0;
+    // Thread3 - It'll not be tangled, because queue size is 1
+    spawnThread({
+        channel2.send(2);
+        result = channel2.receive();
+        synchronized (mutex)
+        {
+            condition.notify;
+        }
+    });
+
+    synchronized (mutex)
+    {
+        condition.wait(1000.msecs);
+    }
+    assert(result == 2);
+}
+
+
+// If the queue size is 0, it will block when it is sent and received on the same fiber.
+unittest
+{
+    auto channel1 = new Channel!int(0);
+    auto channel2 = new Channel!int(1);
+    int result = 0;
+
+    // Thread1
+    spawnThread({
+
+        scope scheduler = thisScheduler;
+        scope cond = scheduler.newCondition(null);
+
+        scheduler.start({
+            //  Fiber1 - It'll be tangled.
+            scheduler.spawn({
+                channel1.send(2);
+                result = channel1.receive();
+                cond.notify();
+            });
+
+            assert(!cond.wait(1000.msecs));
+            assert(result == 0);
+
+            //  Fiber2 - Unravel a tangle
+            scheduler.spawn({
+                result = channel1.receive();
+                channel1.send(2);
+            });
+
+            cond.wait(1000.msecs);
+            assert(result == 2);
+
+            //  Fiber3 - It'll not be tangled, because queue size is 1
+            scheduler.spawn({
+                channel2.send(2);
+                result = channel2.receive();
+                cond.notify();
+            });
+
+            cond.wait(1000.msecs);
+            assert(result == 2);
+        });
+    });
+}

--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -42,6 +42,7 @@ import core.atomic;
 import core.sync.condition;
 import core.sync.mutex;
 import core.thread;
+import std.container;
 import std.range.primitives;
 import std.traits;
 
@@ -1597,4 +1598,445 @@ private:
     auto self = thisTid();
     self.receiveOnly!(bool);
     assert(x[0] == 5);
+}
+
+
+/*******************************************************************************
+
+    This is similar to go channels.
+
+    If you set the size of the queue to 0 in the constructor,
+    you can create unbuffered channel.
+
+    There are two kinds of fiber(thread). One reads, and one writes.
+
+    1.  buffered channel
+        When the write-fiber(thread) is working,
+        it puts the message in the queue.
+
+        When the read-fiber(thread) is working,
+        take the message out of the queue and take it.
+        If there are no messages in the queue, wait for write-fiber(thread) to put
+        the messages in the queue.
+
+    2.  unbuffered channel
+        When the write-fiber(thread) is working,
+        it sends the data to the read-fiber(thread) if it already exists.
+        Otherwise, the write-fiber(thread) waits for the read-fiber(thread)
+        to come in.
+
+        When read-fiber(thread) works,
+        it imports data from the write-fiber(thread) if it already exists.
+        Otherwise, the read-fiber(thread) waits for the write-fiber(thread)
+        to come in.
+
+    Params:
+        T = The type of message to deliver. (int, string, struct, ......)
+
+*******************************************************************************/
+
+public class Channel (T)
+{
+    /// closed
+    private bool closed;
+
+    /// lock for queue and status
+    private Mutex mutex;
+
+    /// size of queue
+    private size_t qsize;
+
+    /// queue of data
+    private DList!T queue;
+
+    /// the number of message in queue
+    private size_t mcount;
+
+    /// collection of send waiters
+    private DList!(ChannelContext!T) sendq;
+
+    /// collection of recv waiters
+    private DList!(ChannelContext!T) recvq;
+
+
+    /***************************************************************************
+
+        Creator
+
+        Params:
+            qsize = If this is 0, it becomes a unbuffered channel.
+            Otherwise, it has a buffer size as large as qsize.
+
+    ***************************************************************************/
+
+    public this (size_t qsize = 0)
+    {
+        this.closed = false;
+        this.mutex = new Mutex;
+        this.qsize = qsize;
+        this.mcount = 0;
+    }
+
+
+    /***************************************************************************
+
+        Send data `msg`.
+
+        Params:
+            msg = message to send
+
+        Return:
+            If successful, return true, otherwise return false
+
+    ***************************************************************************/
+
+    public bool send (T msg)
+    {
+        this.mutex.lock();
+
+        if (this.closed)
+        {
+            this.mutex.unlock();
+            return false;
+        }
+
+        if (!this.recvq.empty)
+        {
+            ChannelContext!T context = this.recvq.front;
+            this.recvq.removeFront();
+            *(context.msg_ptr) = msg;
+            this.mutex.unlock();
+            context.notify();
+            return true;
+        }
+
+        if (this.mcount < this.qsize)
+        {
+            this.queue.insertBack(msg);
+            this.mcount++;
+            this.mutex.unlock();
+            return true;
+        }
+
+        void waitForReader (Mutex mutex, Condition condition)
+        {
+            ChannelContext!T new_context;
+            new_context.msg_ptr = null;
+            new_context.msg = msg;
+            new_context.mutex = mutex;
+            new_context.condition = condition;
+            this.sendq.insertBack(new_context);
+            this.mutex.unlock();
+            new_context.wait();
+        }
+
+        // queue is full or channel is unbuffered
+        auto scheduler = thisScheduler;
+        if (Fiber.getThis() && scheduler !is null)
+        {
+            waitForReader(null, scheduler.newCondition(null));
+            return true;
+        }
+        else
+        {
+            auto mutex = new Mutex();
+            waitForReader(mutex, new Condition(mutex));
+            return true;
+        }
+    }
+
+
+    /***************************************************************************
+
+        Return the received message.
+
+        Return:
+            msg = message to receive
+
+    ***************************************************************************/
+
+    public T receive ()
+    {
+        this.mutex.lock();
+
+        if (this.closed)
+        {
+            this.mutex.unlock();
+            assert(0, "Channel is closed.");
+        }
+
+        if (!this.sendq.empty)
+        {
+            T msg;
+            ChannelContext!T context = this.sendq.front;
+            this.sendq.removeFront();
+            msg = context.msg;
+            this.mutex.unlock();
+            context.notify();
+            return msg;
+        }
+
+        if (!this.queue.empty)
+        {
+            T msg;
+            msg = this.queue.front;
+            this.queue.removeFront();
+            assert(this.mcount > 0, "mcount was zero!");
+            this.mcount--;
+            this.mutex.unlock();
+            return msg;
+        }
+
+        T waitForSender (Mutex mutex, Condition condition)
+        {
+            T msg;
+            ChannelContext!T new_context;
+            new_context.msg_ptr = &msg;
+            new_context.mutex = mutex;
+            new_context.condition = condition;
+            this.recvq.insertBack(new_context);
+            this.mutex.unlock();
+            new_context.wait();
+            return msg;
+        }
+
+        auto scheduler = thisScheduler;
+        if (Fiber.getThis() && scheduler !is null)
+        {
+            return waitForSender(null, scheduler.newCondition(null));
+        }
+        else
+        {
+            auto mutex = new Mutex();
+            return waitForSender(mutex, new Condition(mutex));
+        }
+    }
+
+
+    /***************************************************************************
+
+	    Return the received message.
+
+        Params:
+            msg = point of message to send
+
+        Return:
+            If successful, return true, otherwise return false
+
+    ***************************************************************************/
+
+    public bool tryReceive (T* msg)
+    {
+        assert(msg !is null);
+
+        this.mutex.lock();
+
+        if (this.closed)
+        {
+            this.mutex.unlock();
+            return false;
+        }
+
+        if (!this.sendq.empty)
+        {
+            ChannelContext!T context = this.sendq.front;
+            this.sendq.removeFront();
+            *(msg) = context.msg;
+            this.mutex.unlock();
+            context.notify();
+            return true;
+        }
+
+        if (!this.queue.empty)
+        {
+            *(msg) = this.queue.front;
+            this.queue.removeFront();
+            assert(this.mcount > 0, "mcount was zero!");
+            this.mcount--;
+            this.mutex.unlock();
+            return true;
+        }
+
+        this.mutex.unlock();
+        return false;
+    }
+
+
+    /***************************************************************************
+
+        Return closing status
+
+        Return:
+            If channel is closed, return true, otherwise return false
+
+    ***************************************************************************/
+
+    public @property bool isClosed ()
+    {
+        synchronized (this.mutex)
+        {
+            return this.closed;
+        }
+    }
+
+
+    /***************************************************************************
+
+        Called when the channel is no longer in use.
+        This function turns off Fiber and Thread, which were waiting for
+        the message to pass.
+        And remove the message that was in the queue.
+        And once closed, the channel is no longer available for message passing.
+
+    ***************************************************************************/
+
+    public void close ()
+    {
+        ChannelContext!T context;
+
+        this.mutex.lock();
+        scope (exit) this.mutex.unlock();
+
+        assert(!this.closed, "Channel was already closed!");
+        this.closed = true;
+
+        while (!this.recvq.empty)
+        {
+            context = this.recvq.front;
+            this.recvq.removeFront();
+            context.notify();
+        }
+
+        this.queue.clear();
+        this.mcount = 0;
+
+        while (!this.sendq.empty)
+        {
+            context = this.sendq.front;
+            this.sendq.removeFront();
+            context.notify();
+        }
+    }
+}
+
+/***************************************************************************
+
+    A structure to be stored in a queue.
+    It has information to use in standby.
+
+***************************************************************************/
+
+private struct ChannelContext (T)
+{
+    /// This is a message. Used in put
+    public T  msg;
+
+    /// This is a message pointer. Used in get
+    public T* msg_ptr;
+
+    //  Waiting Condition
+    public Condition condition;
+
+    /// lock for thread waiting
+    public Mutex mutex;
+}
+
+private void wait (T) (ChannelContext!T context)
+{
+    if (context.condition is null)
+        return;
+
+    if (context.mutex is null)
+        context.condition.wait();
+    else
+    {
+        synchronized(context.mutex)
+        {
+            context.condition.wait();
+        }
+    }
+}
+
+private void notify (T) (ChannelContext!T context)
+{
+    if (context.condition is null)
+        return;
+
+    if (context.mutex is null)
+        context.condition.notify();
+    else
+    {
+        synchronized(context.mutex)
+        {
+            context.condition.notify();
+        }
+    }
+}
+
+/// Test of a buffered channel
+unittest
+{
+    void mainTask ()
+    {
+        void otherTask (T) (Channel!T chan)
+        {
+            thisScheduler.spawn({
+                assert(chan.receive() == "Hello World");
+                assert(chan.receive() == "Handing off");
+            });
+        }
+
+        auto chan = new Channel!string(2);
+
+        otherTask(chan);
+
+        chan.send("Hello World");
+        chan.send("Handing off");
+    }
+
+    /// Create FiberScheduler of main thread
+    thisScheduler = new FiberScheduler();
+    thisScheduler.start({
+        mainTask();
+    });
+}
+
+/// Test of a unbuffered channel
+unittest
+{
+    string[] results;
+    void mainTask ()
+    {
+        void otherTask (T) (Channel!T chan)
+        {
+            thisScheduler.spawn({
+                results ~= "+ Ping";
+                chan.receive();
+                results ~= "+ Ping";
+                chan.receive();
+                results ~= "+ Ping";
+                chan.receive();
+            });
+        }
+
+        auto chan = new Channel!int(0);
+
+        otherTask(chan);
+
+        results ~= "* Ping";
+        chan.send(42);
+        results ~= "* Ping";
+        chan.send(42);
+        results ~= "* Ping";
+        chan.send(42);
+        results ~= "* Boom";
+    }
+
+    /// Create FiberScheduler of main thread
+    thisScheduler = new FiberScheduler();
+    thisScheduler.start({
+        mainTask();
+    });
+
+    assert(results == ["+ Ping", "* Ping", "+ Ping", "* Ping", "+ Ping", "* Ping", "* Boom"]);
 }


### PR DESCRIPTION
I tested various cases between threads and pipes.
I have allowed many `FiberSchedulers` to operate in a multi-threaded environment.

The issue is #41 Implement unbuffered channels
I moved to PR #45.