### PR TITLE
Implement  a reliable `FiberScheduler` in multi-threaded environments

### DIFF
--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -824,6 +824,8 @@ struct ThreadInfo
     Tid ident;
     Tid owner;
 
+    public FiberScheduler scheduler;
+
     /**
      * Gets a thread-local instance of ThreadInfo.
      *
@@ -851,6 +853,30 @@ struct ThreadInfo
         if (owner != Tid.init)
             _send(MsgType.linkDead, owner, ident);
     }
+}
+
+
+/***************************************************************************
+
+    Getter of FiberScheduler assigned to a called thread.
+
+***************************************************************************/
+
+public @property FiberScheduler thisScheduler () nothrow
+{
+    return thisInfo.scheduler;
+}
+
+
+/***************************************************************************
+
+    Setter of FiberScheduler assigned to a called thread.
+
+***************************************************************************/
+
+public @property void thisScheduler (FiberScheduler value) nothrow
+{
+    thisInfo.scheduler = value;
 }
 
 

--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -945,6 +945,10 @@ public class InfoThread : Thread
  */
 class FiberScheduler
 {
+
+    /// Whether start() has been called
+    private bool dispatching;
+
     /**
      * This creates a new Fiber for the supplied op and then starts the
      * dispatcher.
@@ -1101,6 +1105,11 @@ private:
     void dispatch()
     {
         import std.algorithm.mutation : remove;
+
+        assert(!this.dispatching, "Already called start(). Scheduling already started.");
+
+        this.dispatching = true;
+        scope (exit) this.dispatching = false;
 
         while (m_fibers.length > 0)
         {

--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -214,16 +214,16 @@ private
             }
         }
     }
+}
 
-    @property ref ThreadInfo thisInfo() nothrow
-    {
-        auto t = cast(InfoThread)Thread.getThis();
+public @property ref ThreadInfo thisInfo() nothrow
+{
+    auto t = cast(InfoThread)Thread.getThis();
 
-        if (t !is null)
-            return t.info;
+    if (t !is null)
+        return t.info;
 
-        return ThreadInfo.thisInfo;
-    }
+    return ThreadInfo.thisInfo;
 }
 
 static ~this()

--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -288,6 +288,18 @@ class TidMissingException : Exception
     mixin basicExceptionCtors;
 }
 
+/**
+ * Thrown on the current thread receives an exit message
+ * from another thread.
+ */
+class SchedulingTerminated : Exception
+{
+    ///
+    this(string msg = "Scheduling terminated") @safe pure nothrow @nogc
+    {
+        super(msg);
+    }
+}
 
 // Thread ID
 


### PR DESCRIPTION
‘start()’ calls during ‘dispatch()’ become ‘assert-failure’.
When the thread terminates, it provides a way for the scheduling to terminate reliably.
Change to `public` visibility attribute of thisInfo

The issue is #48 
This depends on PR #45 