### PR TITLE
Throw an Exception type when a method isn't found

### DIFF
--- a/source/geod24/Exception.d
+++ b/source/geod24/Exception.d
@@ -1,0 +1,17 @@
+/*******************************************************************************
+
+    Defines the exception class thrown when an unimplemented API method
+    is called, or one with the wrong parameters is attempted to be called.
+
+*******************************************************************************/
+
+module geod24.Exception;
+
+import std.exception;
+
+/// ditto
+public class UnhandledMethodException : Exception
+{
+    ///
+    mixin basicExceptionCtors;
+}

--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -78,6 +78,8 @@
 
 module geod24.LocalRest;
 
+import geod24.Exception;
+
 import vibe.data.json;
 
 static import C = geod24.concurrency;
@@ -386,7 +388,8 @@ public final class RemoteAPI (API) : API
                 }.format(member, ovrld.mangleof));
             }
         default:
-            assert(0, "Unmatched method name: " ~ cmd.method);
+            throw new UnhandledMethodException(cmd.method);
+            //assert(0, "Unmatched method name: " ~ cmd.method);
         }
     }
 


### PR DESCRIPTION

There was a need to catch exceptions when we cannot find the requested method.
Relates https://github.com/bpfkorea/agora/pull/756