### PR TITLE
Fix inverted condition for timed get

### DIFF
--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -1075,7 +1075,7 @@ package class MessageBox
     bool get(Ops...)(Duration period, scope Ops ops)
     {
         immutable timedWait = period !is Duration.init;
-        MonoTime limit = timedWait ? MonoTime.init : MonoTime.currTime + period;
+        MonoTime limit = timedWait ? MonoTime.currTime + period : MonoTime.init;
 
         bool onStandardMsg(ref Message msg)
         {


### PR DESCRIPTION
Caught by Andrej post merge, the condition was actually inverted,
if the wait is timed, the limit shouldn't be MonoTime.init