### PR TITLE
FiberScheduler: Make sure the argument to start gets run first

### DIFF
--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -830,6 +830,8 @@ class FiberScheduler
     void start(void delegate() op)
     {
         create(op);
+        // Make sure the just-created fiber is run first
+        this.m_pos = this.m_fibers.length - 1;
         dispatch();
     }
 
@@ -1002,6 +1004,15 @@ private:
 private:
     Fiber[] m_fibers;
     size_t m_pos;
+}
+
+/// Ensure argument to `start` is run first
+unittest
+{
+    scope sched = new FiberScheduler();
+    bool startHasRun;
+    sched.spawn(() => assert(startHasRun));
+    sched.start(() { startHasRun = true; });
 }
 
 /*


### PR DESCRIPTION
Before, one could call 'runTask' before calling start, and on the first run those tasks would execute first,
as the scheduler iterates through the array.