### PR TITLE
Change the InfoFiber stack size

### DIFF
--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -926,7 +926,7 @@ protected:
     {
         ThreadInfo info;
 
-        this(void delegate() op, size_t sz = 16 * 1024 * 1024) nothrow
+        this(void delegate() op, size_t sz = 512 * 1024) nothrow
         {
             super(op, sz);
         }


### PR DESCRIPTION
This resolves the memory allocation fail issue in the GitHub Actions Windows-2019 OS Environment Test.
Stack size must be downsized on Windows due to overcommit memory.