### PR TITLE
Implement resource management in FiberScheduler

### DIFF
--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -110,24 +110,11 @@ import std.traits : fullyQualifiedName, Parameters, ReturnType;
 import core.thread;
 import core.time;
 
-/// Request / Response ID
-private struct ID
-{
-    /// A node may restart, in which case it will spawn a new request scheduler
-    size_t sched_id;
-    /// In order to support re-entrancy, every request contains an id
-    /// which should be copied in the `Response`
-    /// Initialized to `size_t.max` so not setting it crashes the program
-    size_t id = size_t.max;
-}
-
 /// Data sent by the caller
 private struct Command
 {
-    /// Tid of the sender thread (cannot be JSON serialized)
-    C.Tid sender;
-    /// ID used for request re-entrancy (See ID definition)
-    ID id;
+    /// Sequence id of Command
+    size_t id;
     /// Method to call
     string method;
     /// Serialized arguments to the method
@@ -144,10 +131,10 @@ private struct TimeCommand
 }
 
 /// Ask the node to shut down
-private struct ShutdownCommand (API)
+private struct ShutdownCommand
 {
     /// Any callback to call before the Node's destructor is called
-    void function (API) callback;
+    void function (Object) callback;
 
     /// Whether we're restarting or really shutting down
     bool restart;
@@ -184,8 +171,8 @@ private struct Response
 {
     /// Final status of a request (failed, timeout, success, etc)
     Status status;
-    /// ID used for request re-entrancy (See ID definition)
-    ID id;
+    /// Response id
+    size_t id;
     /// If `status == Status.Success`, the serialized return value.
     /// Otherwise, it contains `Exception.toString()`.
     SerializedData data;
@@ -212,75 +199,216 @@ private struct ArgWrapper (T...)
     T args;
 }
 
-/// Our own little scheduler
-private final class LocalScheduler : C.FiberScheduler
+// very simple & limited variant, to keep it performant.
+// should be replaced by a real Variant later
+private struct Variant
 {
-    import core.sync.condition;
-    import core.sync.mutex;
+    this (Command msg) { this.cmd = msg; this.tag = Variant.Type.command; }
+    this (Response msg) { this.res = msg; this.tag = Variant.Type.response; }
+    this (FilterAPI msg) { this.filter = msg; this.tag = Variant.Type.filter; }
+    this (TimeCommand msg) { this.time = msg; this.tag = Variant.Type.timeCommand; }
+    this (ShutdownCommand msg) { this.shutdown = msg; this.tag = Variant.Type.shutdownCommand; }
 
-    /// Just a FiberBinarySemaphore with a state
-    private struct Waiting { FiberBinarySemaphore s; bool busy; }
-
-    /// The 'Response' we are currently processing, if any
-    private Response pending;
-
-    /// Request IDs waiting for a response
-    private Waiting[ID] waiting;
-
-    /// scheduler ID
-    private size_t sched_id;
-
-    /// Initialize this scheduler and its unique ID
-    public this () @safe @nogc nothrow
+    union
     {
-        static size_t last_idx;
-        this.sched_id = last_idx++;
+        Command cmd;
+        Response res;
+        FilterAPI filter;
+        TimeCommand time;
+        ShutdownCommand shutdown;
     }
 
-    /// Get the next available request ID
-    public ID getNextResponseId ()
+    Type tag;
+
+    /// Type of a request
+    enum Type : ubyte
     {
-        static size_t last_idx;
-        return ID(this.sched_id, last_idx++);
-    }
-
-    public Response waitResponse (ID id, Duration duration) nothrow
-    {
-        if (id !in this.waiting)
-            this.waiting[id] = Waiting(new FiberBinarySemaphore, false);
-
-        Waiting* ptr = &this.waiting[id];
-        if (ptr.busy)
-            assert(0, "Trying to override a pending request");
-
-        // We yield and wait for an answer
-        ptr.busy = true;
-
-        if (duration == Duration.init)
-            ptr.s.wait();
-        else if (!ptr.s.wait(duration))
-            this.pending = Response(Status.Timeout, this.pending.id);
-
-        ptr.busy = false;
-        // After control returns to us, `pending` has been filled
-        scope(exit) this.pending = Response.init;
-        return this.pending;
-    }
-
-    /// Called when a waiting condition was handled and can be safely removed
-    public void remove (ID id)
-    {
-        this.waiting.remove(id);
+        command,
+        response,
+        filter,
+        timeCommand,
+        shutdownCommand,
     }
 }
 
+private alias CommandChn = C.Channel!Variant;
+private alias RespChn = C.Channel!Response;
+
+/// Represents a connection between a server and a client
+private class Connection
+{
+    ///
+    this () nothrow
+    {
+        this.command_chn = new CommandChn();
+        this.resp_chn = new RespChn();
+    }
+
+    /*******************************************************************************
+
+        Send a message over the Connection
+
+        Params:
+            T = Type of the message, should be support by the `Variant` type
+            msg = Message to be sent
+
+        Returns:
+            Success/failure
+
+    *******************************************************************************/
+
+    bool sendCommand (T) (T msg) @trusted
+    {
+        bool ret;
+
+        if (isMainThread())
+            scheduler.start({ ret = this.command_chn.write(Variant(msg)); });
+        else
+            ret = this.command_chn.write(Variant(msg));
+
+        return ret;
+    }
+
+    /*******************************************************************************
+
+        Get a unique id for a `Command` to be sent from this `Connection`
+
+        Returns:
+            Unique Command id
+
+    *******************************************************************************/
+
+    size_t getNextCommandId () @safe
+    {
+        return this.next_cmd_id++;
+    }
+
+    /*******************************************************************************
+
+        Wait for a `Response` with specific id
+
+        Params:
+            resp_id = Response id to wait for
+            timeout = optional timeout duration for the operation
+
+        Returns:
+            Response
+
+    *******************************************************************************/
+
+    Response waitResponse (size_t resp_id, Duration timeout = Duration.init) @trusted
+    {
+        if (isMainThread())
+        {
+            Response res;
+            scheduler.start({
+                // Loop until we get the Response we are looking for
+                while (this.resp_chn.read(res, timeout))
+                    if (res.id == resp_id)
+                        return;
+                res = Response(Status.Timeout, resp_id, SerializedData("Request timed-out"));
+            });
+            return res;
+        }
+        else
+        {
+            // Response may already be ready
+            if (auto existing_res = (resp_id in this.waiting_list))
+                return existing_res.res;
+
+            // Block while waiting the Response
+            auto blocker = C.thisScheduler().new FiberBlocker();
+            this.waiting_list[resp_id] = Waiting(blocker);
+            if (blocker.wait(timeout))
+                return this.waiting_list[resp_id].res;
+            else
+                return Response(Status.Timeout, resp_id, SerializedData("Request timed-out"));
+        }
+    }
+
+    /*******************************************************************************
+
+        Notify the task waiting for a Response
+
+        Params:
+            res = Newly arrived Response
+
+    *******************************************************************************/
+
+    void notifyWaiter (Response res)
+    {
+        // Is the waiting Fiber already blocked?
+        if (auto waiter = (res.id in this.waiting_list))
+        {
+            waiter.res = res;
+            waiter.blocker.notify();
+        }
+        else // Fiber is not yet blocked, create an entry for the related Fiber to use
+            this.waiting_list[res.id] = Waiting(null, res);
+    }
+
+    /*******************************************************************************
+
+        Close the `Channel`s associated with this `Connection`. Blocked `waitResponse`
+        calls will timeout and blocked `sendCommand` calls will fail
+
+    *******************************************************************************/
+
+    void close ()
+    {
+        this.command_chn.close();
+        this.resp_chn.close();
+    }
+
+    ///
+    private struct Waiting
+    {
+        C.FiberScheduler.FiberBlocker blocker;
+        Response res;
+    }
+
+    /// List of Fibers waiting for a Response from this Connection
+    private Waiting[size_t] waiting_list;
+
+    /// Next Command ID
+    private size_t next_cmd_id;
+
+    /// Channel to send `Command`s to
+    private CommandChn command_chn;
+
+    /// Channel to read `Response`s from
+    private RespChn resp_chn;
+}
+
+/// `Channel` type that the nodes will listen for new `Connection`s
+public alias BindChn = C.Channel!Connection;
+
+/// Thread local outgoing `Connection` list
+private Connection[RespChn] outgoing_conns;
+
+/// Thread local incoming `Connection` list
+private Connection[CommandChn] incoming_conns;
 
 /// We need a scheduler to simulate an event loop and to be re-entrant
-private LocalScheduler scheduler;
+private C.FiberScheduler scheduler;
 
-/// Whether this is the main thread
-private bool is_main_thread;
+/***********************************************************************
 
+    Check if the current context is running inside the main thread and
+    intialize the thread local fiber scheduler if it is not initialized
+
+    Returns:
+        If the context is the main thread or not
+
+***********************************************************************/
+
+private bool isMainThread () @trusted nothrow
+{
+    // we are in the main thread
+    if (scheduler is null)
+        scheduler = new C.FiberScheduler;
+    return C.thisScheduler() is null;
+}
 
 /*******************************************************************************
 
@@ -302,16 +430,21 @@ private bool is_main_thread;
 
 public void runTask (void delegate() dg) nothrow
 {
-    assert(scheduler !is null, "Cannot call this function from the main thread");
+    assert(!isMainThread(), "Cannot call this function from the main thread");
     scheduler.spawn(dg);
 }
 
 /// Ditto
 public void sleep (Duration timeout) nothrow
 {
-    assert(scheduler !is null, "Cannot call this function from the main thread");
-    scope sem = scheduler.new FiberBinarySemaphore();
-    sem.wait(timeout);
+    assert(!isMainThread(), "Cannot call this function from the main thread");
+
+    // Duration.init (0.seconds) is infinite timeout, ignore
+    if (timeout == Duration.init)
+        return;
+
+    scope blocker = scheduler.new FiberBlocker();
+    blocker.wait(timeout);
 }
 
 /*******************************************************************************
@@ -440,8 +573,12 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
         CtorParams!Impl args, Duration timeout = Duration.init,
         string file = __FILE__, int line = __LINE__)
     {
-        auto childTid = C.spawn(&spawned!(Impl), file, line, args);
-        return new RemoteAPI(childTid, timeout);
+        auto chn = new BindChn();
+        new Thread(
+        {
+            spawned!(Impl)(chn, file, line, args);
+        }).start();
+        return new RemoteAPI(chn, timeout);
     }
 
     /// Helper template to get the constructor's parameters
@@ -464,10 +601,11 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
             cmd    = the command to run (contains the method name and the arguments)
             node   = the node to invoke the method on
             filter = used for filtering API calls (returns default response)
+            resp_chn = `Channel` to send the `Response` to
 
     ***************************************************************************/
 
-    private static void handleCommand (Command cmd, API node, FilterAPI filter)
+    private static void handleCommand (Command cmd, API node, FilterAPI filter, RespChn resp_chn)
     {
         switch (cmd.method)
         {
@@ -502,14 +640,13 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
                         }
                     }
 
-                    C.trySend(cmd.sender, res);
+                    resp_chn.write(res);
                     return;
                 }.format(member, ovrld.mangleof));
             }
         default:
-            C.trySend(cmd.sender,
-                      Response(Status.ClientFailed, cmd.id,
-                               SerializedData("Method not found")));
+            resp_chn.write(Response(Status.ClientFailed, cmd.id, SerializedData("Method not found")));
+            break;
         }
     }
 
@@ -518,14 +655,12 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
         Main dispatch function
 
        This function receive string-serialized messages from the calling thread,
-       which is a struct with the sender's Tid, the method's mangleof,
-       and the method's arguments as a tuple, serialized to a JSON string.
-
-       `geod24.concurrency.receive` is not `@safe`, so neither is this.
+       which is a struct with the method's mangleof, and the method's arguments
+       as a tuple, serialized to a JSON string.
 
        Params:
            Implementation = Type of the implementation to instantiate
-           self = The channel on which to "listen" to receive new "connections"
+           bind_chn = The channel on which to "listen" to receive new "connections"
            file = Path to the file that spawned this node
            line = Line number in the `file` that spawned this node
            cargs = Arguments to `Implementation`'s constructor
@@ -533,7 +668,7 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
     ***************************************************************************/
 
     private static void spawned (Implementation) (
-        C.Tid self, string file, int line, CtorParams!Implementation cargs)
+        BindChn bind_chn, string file, int line, CtorParams!Implementation cargs)
         nothrow
     {
         import std.datetime.systime : Clock, SysTime;
@@ -549,22 +684,6 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
             {
                 super("You should never see this exception - please report a bug");
             }
-        }
-
-        // very simple & limited variant, to keep it performant.
-        // should be replaced by a real Variant later
-        static struct Variant
-        {
-            this (Response res) { this.res = res; this.tag = 0; }
-            this (Command cmd) { this.cmd = cmd; this.tag = 1; }
-
-            union
-            {
-                Response res;
-                Command cmd;
-            }
-
-            ubyte tag;
         }
 
         // used for controling filtering / sleep
@@ -586,72 +705,109 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
         void runNode ()
         {
             scope node = new Implementation(cargs);
-            scheduler = new LocalScheduler;
+            scheduler = new C.FiberScheduler;
 
             // Control the node behavior
             Control control;
 
+            struct AwaitingMessage
+            {
+                /// Message
+                Variant var;
+                /// Originating `Connection`
+                Connection conn;
+            }
             // we need to keep track of messages which were ignored when
             // node.sleep() was used, and then handle each message in sequence.
-            Variant[] await_msgs;
-
-            void handle (T)(T arg)
-            {
-                static if (is(T == Command))
-                {
-                    scheduler.spawn(() => handleCommand(arg, node, control.filter));
-                }
-                else static if (is(T == Response))
-                {
-                    // response for a previous LocalScheduler instance
-                    if (arg.id.sched_id != scheduler.sched_id)
-                        return;
-
-                    scheduler.pending = arg;
-                    scheduler.waiting[arg.id].s.notify();
-                    scheduler.remove(arg.id);
-                }
-                else static assert(0, "Unhandled type: " ~ T.stringof);
-            }
+            AwaitingMessage[] await_msgs;
 
             scheduler.start(() {
-                while (1)
-                {
-                    C.receiveTimeout(self, 10.msecs,
-                        (ShutdownCommand!API e)
-                        {
-                            if (e.callback !is null)
-                                e.callback(node);
-                            exc.restart = e.restart;
-                            throw exc;
-                        },
-                        (TimeCommand s) {
-                            control.sleep_until = Clock.currTime + s.dur;
-                            control.drop = s.drop;
-                        },
-                        (FilterAPI filter_api) {
-                            control.filter = filter_api;
-                        },
-                        (Response res) {
-                            if (!control.isSleeping())
-                                handle(res);
-                            else if (!control.drop)
-                                await_msgs ~= Variant(res);
-                        },
-                        (Command cmd)
-                        {
-                            if (!control.isSleeping())
-                                handle(cmd);
-                            else if (!control.drop)
-                                await_msgs ~= Variant(cmd);
-                        });
+                C.SelectEntry[] read_list;
+                C.SelectEntry[] write_list;
 
-                    // now handle any leftover messages after any sleep() call
+                while (true)
+                {
+                    Connection new_conn;
+                    Response res;
+                    Variant msg;
+
+                    read_list.length = 0;
+                    assumeSafeAppend(read_list);
+                    write_list.length = 0;
+                    assumeSafeAppend(write_list);
+
+                    foreach (ref conn; incoming_conns)
+                        if (!conn.command_chn.isClosed())
+                            read_list ~= C.SelectEntry(conn.command_chn, &msg);
+                    foreach (ref conn; outgoing_conns)
+                        if (!conn.resp_chn.isClosed())
+                            read_list ~= C.SelectEntry(conn.resp_chn, &res);
+                    read_list ~= C.SelectEntry(bind_chn, &new_conn);
+
+                    auto sel_ret = C.select(read_list, write_list, 10.msecs);
+
                     if (!control.isSleeping())
                     {
-                        await_msgs.each!(msg => msg.tag == 0 ? handle(msg.res) : handle(msg.cmd));
+                        foreach (ref await_msg; await_msgs)
+                            handleCommand(await_msg.var.cmd, node, control.filter, await_msg.conn.resp_chn);
                         await_msgs.length = 0;
                         assumeSafeAppend(await_msgs);
+                    }
+
+                    if (!sel_ret.success)
+                        continue;
+
+                    // Bind chn
+                    if (cast(BindChn) read_list[sel_ret.id].selectable)
+                    {
+                        incoming_conns[new_conn.command_chn] = new_conn;
+                    }
+                    // Command
+                    else if (auto comm_chn = cast(CommandChn) read_list[sel_ret.id].selectable)
+                    {
+                        auto curr_conn = incoming_conns[comm_chn];
+                        switch (msg.tag)
+                        {
+                            case Variant.Type.command:
+                                Command cmd = msg.cmd;
+                                if (!control.isSleeping())
+                                    scheduler.spawn({
+                                        handleCommand(cmd, node, control.filter, curr_conn.resp_chn);
+                                    });
+                                else if (!control.drop)
+                                    await_msgs ~= AwaitingMessage(msg, curr_conn);
+                                break;
+                            case Variant.Type.shutdownCommand:
+                                ShutdownCommand e = msg.shutdown;
+                                if (!e.restart)
+                                {
+                                    bind_chn.close();
+                                    incoming_conns.each!((conn) => conn.close());
+                                }
+                                outgoing_conns.each!((conn) => conn.close());
+                                outgoing_conns.clear();
+
+                                if (e.callback !is null)
+                                    e.callback(node);
+                                exc.restart = e.restart;
+                                throw exc;
+                            case Variant.Type.timeCommand:
+                                TimeCommand s = msg.time;
+                                control.sleep_until = Clock.currTime + s.dur;
+                                control.drop = s.drop;
+                                break;
+                            case Variant.Type.filter:
+                                FilterAPI filter_api = msg.filter;
+                                control.filter = filter_api;
+                                break;
+                            default:
+                                assert(0, "Got invalid Variant.Type: " ~ msg.tag);
+                        }
+                    }
+                    else if (auto resp_chn = cast(RespChn) read_list[sel_ret.id].selectable)
+                    {
+                        // Response
+                        outgoing_conns[resp_chn].notifyWaiter(res);
                     }
                 }
             });
@@ -684,11 +840,14 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
         }
     }
 
-    /// Where to send message to
-    private C.Tid childTid;
-
     /// Timeout to use when issuing requests
     private const Duration timeout;
+
+    /// Main Channel that this Node will listen for incoming messages
+    private BindChn bind_chn;
+
+    /// Connection between this instance and the node main thread
+    private Connection conn;
 
     /***************************************************************************
 
@@ -698,17 +857,28 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
         In order to instantiate a node, see the static `spawn` function.
 
         Params:
-          tid = `geod24.concurrency.Tid` of the node.
+          bind_chn = `BindChn` of the node.
                 This can usually be obtained by `geod24.concurrency.locate`.
           timeout = any timeout to use
 
     ***************************************************************************/
 
-    public this (C.Tid tid, Duration timeout = Duration.init)
-        @safe @nogc pure nothrow
+    public this (BindChn bind_chn, Duration timeout = Duration.init) @trusted nothrow
     {
-        this.childTid = tid;
+        import std.exception : assumeWontThrow;
+
+        this.bind_chn = bind_chn;
         this.timeout = timeout;
+        assert(bind_chn);
+
+        // Create a new Connection, register it and send it to the peer
+        // TODO: What to do when bind_chn is closed?
+        this.conn = new Connection();
+        outgoing_conns[this.conn.resp_chn] = this.conn;
+        if (isMainThread())
+            assumeWontThrow(scheduler.start({ bind_chn.write(this.conn); }));
+        else
+            bind_chn.write(this.conn);
     }
 
     /***************************************************************************
@@ -729,17 +899,16 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
     {
         /***********************************************************************
 
-            Returns the `Tid` this `RemoteAPI` wraps
+            Returns the `BindChn` main thread of this `RemoteAPI` listens to
+            for new `Connections`
 
             This can be useful for calling `geod24.concurrency.register` or similar.
-            Note that the `Tid` should not be used directly, as our event loop,
-            would error out on an unknown message.
 
         ***********************************************************************/
 
-        public C.Tid tid () @nogc pure nothrow
+        public BindChn chn () @nogc pure nothrow
         {
-            return this.childTid;
+            return this.bind_chn;
         }
 
         /***********************************************************************
@@ -753,10 +922,10 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
 
         ***********************************************************************/
 
-        public void shutdown (void function (API) callback = null)
+        public void shutdown (void function (Object) callback = null)
             @trusted
         {
-            C.send(this.childTid, ShutdownCommand!API(callback, false));
+            this.conn.sendCommand(ShutdownCommand(callback, false));
         }
 
         /***********************************************************************
@@ -773,19 +942,15 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
 
         ***********************************************************************/
 
-        public void restart (void function (API) callback = null)
+        public void restart (void function (Object) callback = null)
             @trusted
         {
-            C.send(this.childTid, ShutdownCommand!API(callback, true));
+            this.conn.sendCommand(ShutdownCommand(callback, true));
         }
 
         /***********************************************************************
 
             Make the remote node sleep for `Duration`
-
-            The remote node will call `Thread.sleep`, becoming completely
-            unresponsive, potentially having multiple tasks hanging.
-            This is useful to simulate a delay or a network outage.
 
             Params:
               delay = Duration the node will sleep for
@@ -797,7 +962,7 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
 
         public void sleep (Duration d, bool dropMessages = false) @trusted
         {
-            C.send(this.childTid, TimeCommand(d, dropMessages));
+            this.conn.sendCommand(TimeCommand(d, dropMessages));
         }
 
         /***********************************************************************
@@ -876,7 +1041,7 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
                 enum mangled = getBestMatch!Overloads;
             }
 
-            C.send(this.childTid, FilterAPI(mangled, pretty));
+            this.conn.sendCommand(FilterAPI(mangled, pretty));
         }
 
 
@@ -888,7 +1053,7 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
 
         public void clearFilter () @trusted
         {
-            C.send(this.childTid, FilterAPI(""));
+            this.conn.sendCommand(FilterAPI(""));
         }
 
         /***********************************************************************
@@ -911,7 +1076,7 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
 
         public void withTimeout (Dg) (Duration timeout, scope Dg dg)
         {
-            scope api = new RemoteAPI(this.childTid, timeout);
+            scope api = new RemoteAPI(this.bind_chn, timeout);
             static assert(is(typeof({ dg(api); })),
                           "Provided argument of type `" ~ Dg.stringof ~
                           "` is not callable with argument type `scope " ~
@@ -935,56 +1100,16 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
             mixin(q{
                 override ReturnType!(ovrld) } ~ member ~ q{ (Parameters!ovrld params)
                 {
-                    // we are in the main thread
-                    if (scheduler is null)
-                    {
-                        scheduler = new LocalScheduler;
-                        is_main_thread = true;
-                    }
 
                     // `geod24.concurrency.send/receive[Only]` is not `@safe` but
                     // this overload needs to be
                     auto res = () @trusted {
                         auto serialized = S.serialize(ArgWrapper!(Parameters!ovrld)(params));
+                        auto command = Command(this.conn.getNextCommandId(), ovrld.mangleof, SerializedData(serialized));
 
-                        auto command = Command(C.thisTid(), scheduler.getNextResponseId(), ovrld.mangleof,
-                                               SerializedData(serialized));
-
-                        // If the node already shut down, its MessageBox will be
-                        // closed. Detect it and notify the user.
-                        // Note that it might be expected that the remote died.
-                        if (!C.trySend(this.childTid, command))
+                        if(!this.conn.sendCommand(command))
                             throw new Exception("Connection with peer closed");
-
-                        // for the main thread, we run the "event loop" until
-                        // the request we're interested in receives a response.
-                        if (is_main_thread)
-                        {
-                            bool terminated = false;
-                            runTask(() {
-                                while (!terminated)
-                                {
-                                    C.receiveTimeout(C.thisTid(), 10.msecs,
-                                        (Response res) {
-                                            scheduler.pending = res;
-                                            scheduler.waiting[res.id].s.notify();
-                                        });
-
-                                    scheduler.yield();
-                                }
-                            });
-
-                            Response res;
-                            scheduler.start(() {
-                                res = scheduler.waitResponse(command.id, this.timeout);
-                                terminated = true;
-                            });
-                            return res;
-                        }
-                        else
-                        {
-                            return scheduler.waitResponse(command.id, this.timeout);
-                        }
+                        return this.conn.waitResponse(command.id, this.timeout);
                     }();
 
                     if (res.status == Status.Failed)
@@ -1058,7 +1183,7 @@ unittest
         ~this () { dtor_called = true; }
     }
 
-    static void onDestroy (API node)
+    static void onDestroy (Object node)
     {
         assert(!dtor_called);
         auto mock = cast(MockAPI)node;
@@ -1120,19 +1245,19 @@ unittest
     static RemoteAPI!API factory (string type, ulong hash)
     {
         const name = hash.to!string;
-        auto tid = registry.locate(name);
-        if (tid != tid.init)
-            return new RemoteAPI!API(tid);
+        auto chn = registry.locate(name);
+        if (chn !is null)
+            return new RemoteAPI!API(chn);
 
         switch (type)
         {
         case "normal":
             auto ret =  RemoteAPI!API.spawn!Node(false);
-            registry.register(name, ret.tid());
+            registry.register(name, ret.chn());
             return ret;
         case "byzantine":
             auto ret =  RemoteAPI!API.spawn!Node(true);
-            registry.register(name, ret.tid());
+            registry.register(name, ret.chn());
             return ret;
         default:
             assert(0, type);
@@ -1198,9 +1323,9 @@ unittest
     static class SlaveNode : API
     {
         @safe:
-        this(Tid masterTid)
+        this(BindChn masterChn)
         {
-            this.master = new RemoteAPI!API(masterTid);
+            this.master = new RemoteAPI!API(masterChn);
         }
 
         public override @property ulong requests()
@@ -1221,9 +1346,9 @@ unittest
     RemoteAPI!API[4] nodes;
     auto master = RemoteAPI!API.spawn!MasterNode();
     nodes[0] = master;
-    nodes[1] = RemoteAPI!API.spawn!SlaveNode(master.tid());
-    nodes[2] = RemoteAPI!API.spawn!SlaveNode(master.tid());
-    nodes[3] = RemoteAPI!API.spawn!SlaveNode(master.tid());
+    nodes[1] = RemoteAPI!API.spawn!SlaveNode(master.chn());
+    nodes[2] = RemoteAPI!API.spawn!SlaveNode(master.chn());
+    nodes[3] = RemoteAPI!API.spawn!SlaveNode(master.chn());
 
     foreach (n; nodes)
     {
@@ -1250,7 +1375,7 @@ unittest
 {
     static import geod24.concurrency;
 
-    __gshared C.Tid[string] tbn;
+    __gshared BindChn[string] tbn;
 
     static interface API
     {
@@ -1284,7 +1409,7 @@ unittest
     ];
 
     foreach (idx, ref api; nodes)
-        tbn[format("node%d", idx)] = api.tid();
+        tbn[format("node%d", idx)] = api.chn();
     nodes[0].setNext("node1");
     nodes[1].setNext("node2");
     nodes[2].setNext("node0");
@@ -1366,7 +1491,7 @@ unittest
 
     auto node = RemoteAPI!API.spawn!Node();
     assert(node.tid == 42);
-    assert(node.ctrl.tid != Tid.init);
+    assert(node.ctrl.chn !is null);
 
     static interface DoesntWork
     {
@@ -1380,7 +1505,7 @@ unittest
 // Simulate temporary outage
 unittest
 {
-    __gshared C.Tid n1tid;
+    __gshared BindChn n1chn;
 
     static interface API
     {
@@ -1391,8 +1516,8 @@ unittest
     {
         public this()
         {
-            if (n1tid != C.Tid.init)
-                this.remote = new RemoteAPI!API(n1tid);
+            if (n1chn !is null)
+                this.remote = new RemoteAPI!API(n1chn);
         }
 
         public override ulong call () { return ++this.count; }
@@ -1402,7 +1527,7 @@ unittest
     }
 
     auto n1 = RemoteAPI!API.spawn!Node();
-    n1tid = n1.tid();
+    n1chn = n1.chn();
     auto n2 = RemoteAPI!API.spawn!Node();
 
     /// Make sure calls are *relatively* efficient
@@ -1451,8 +1576,7 @@ unittest
 // Filter commands
 unittest
 {
-    __gshared C.Tid node_tid;
-
+    __gshared BindChn node_chn;
     static interface API
     {
         size_t fooCount();
@@ -1473,11 +1597,6 @@ unittest
         size_t bar_count;
         RemoteAPI!API remote;
 
-        public this()
-        {
-            this.remote = new RemoteAPI!API(node_tid);
-        }
-
         override size_t fooCount() { return this.foo_count; }
         override size_t fooIntCount() { return this.foo_int_count; }
         override size_t barCount() { return this.bar_count; }
@@ -1490,6 +1609,9 @@ unittest
 
         override void callFoo()
         {
+            if (!this.remote)
+                this.remote = new RemoteAPI!API(node_chn);
+
             try
             {
                 this.remote.foo();
@@ -1502,6 +1624,9 @@ unittest
 
         override void callFoo(int arg)
         {
+            if (!this.remote)
+                this.remote = new RemoteAPI!API(node_chn);
+
             try
             {
                 this.remote.foo(arg);
@@ -1514,6 +1639,9 @@ unittest
 
         override void callBar(int arg)
         {
+            if (!this.remote)
+                this.remote = new RemoteAPI!API(node_chn);
+
             try
             {
                 this.remote.bar(arg);
@@ -1526,7 +1654,7 @@ unittest
     }
 
     auto filtered = RemoteAPI!API.spawn!Node();
-    node_tid = filtered.tid();
+    node_chn = filtered.chn();
 
     // caller will call filtered
     auto caller = RemoteAPI!API.spawn!Node();
@@ -1638,7 +1766,7 @@ unittest
     assert(called);
 
     // Test that attributes are inferred based on the delegate
-    void doTest () @safe pure nothrow @nogc
+    void doTest () @safe nothrow
     {
         called = false;
         node.ctrl.withTimeout(Duration.zero,
@@ -1714,7 +1842,7 @@ unittest
     static import geod24.concurrency;
     import std.exception;
 
-    __gshared C.Tid node_tid;
+    __gshared BindChn node_chn;
 
     static interface API
     {
@@ -1728,7 +1856,7 @@ unittest
 
         override void check ()
         {
-            auto node = new RemoteAPI!API(node_tid, 500.msecs);
+            auto node = new RemoteAPI!API(node_chn, 500.msecs);
 
             // no time-out
             node.ctrl.sleep(10.msecs);
@@ -1742,7 +1870,7 @@ unittest
 
     auto node_1 = RemoteAPI!API.spawn!Node();
     auto node_2 = RemoteAPI!API.spawn!Node();
-    node_tid = node_2.tid;
+    node_chn = node_2.chn();
     node_1.check();
     node_1.ctrl.shutdown();
     node_2.ctrl.shutdown();
@@ -1755,7 +1883,7 @@ unittest
     static import geod24.concurrency;
     import std.exception;
 
-    __gshared C.Tid node_tid;
+    __gshared BindChn node_chn;
 
     static interface API
     {
@@ -1771,7 +1899,7 @@ unittest
 
         override void check ()
         {
-            auto node = new RemoteAPI!API(node_tid, 500.msecs);
+            auto node = new RemoteAPI!API(node_chn, 500.msecs);
 
             // time-out
             node.ctrl.sleep(2000.msecs);
@@ -1785,7 +1913,7 @@ unittest
 
     auto node_1 = RemoteAPI!API.spawn!Node();
     auto node_2 = RemoteAPI!API.spawn!Node();
-    node_tid = node_2.tid;
+    node_chn = node_2.chn();
     node_1.check();
     node_1.ctrl.shutdown();
     node_2.ctrl.shutdown();
@@ -1798,7 +1926,7 @@ unittest
     static import geod24.concurrency;
     import std.exception;
 
-    __gshared C.Tid node_tid;
+    __gshared BindChn node_chn;
 
     static interface API
     {
@@ -1812,7 +1940,7 @@ unittest
 
         override void check ()
         {
-            auto node = new RemoteAPI!API(node_tid, 420.msecs);
+            auto node = new RemoteAPI!API(node_chn, 420.msecs);
 
             // Requests are dropped, so it times out
             assert(node.ping() == 42);
@@ -1823,12 +1951,13 @@ unittest
 
     auto node_1 = RemoteAPI!API.spawn!Node();
     auto node_2 = RemoteAPI!API.spawn!Node();
-    node_tid = node_2.tid;
+    node_chn = node_2.chn();
     node_1.check();
     node_1.ctrl.shutdown();
     node_2.ctrl.shutdown();
     thread_joinAll();
 }
+
 
 // Test a node that gets a replay while it's delayed
 unittest
@@ -1836,7 +1965,7 @@ unittest
     static import geod24.concurrency;
     import std.exception;
 
-    __gshared C.Tid node_tid;
+    __gshared BindChn node_chn;
 
     static interface API
     {
@@ -1850,7 +1979,7 @@ unittest
 
         override void check ()
         {
-            auto node = new RemoteAPI!API(node_tid, 5000.msecs);
+            auto node = new RemoteAPI!API(node_chn, 5000.msecs);
             assert(node.ping() == 42);
             // We need to return immediately so that the main thread
             // puts us to sleep
@@ -1863,7 +1992,7 @@ unittest
 
     auto node_1 = RemoteAPI!API.spawn!Node(500.msecs);
     auto node_2 = RemoteAPI!API.spawn!Node();
-    node_tid = node_2.tid;
+    node_chn = node_2.chn();
     node_1.check();
     node_1.ctrl.sleep(300.msecs);
     assert(node_1.ping() == 42);
@@ -1910,7 +2039,7 @@ unittest
 {
     import core.thread : thread_joinAll;
     static import geod24.concurrency;
-    __gshared C.Tid node_tid;
+    __gshared BindChn node_chn;
 
     static interface API
     {
@@ -1927,7 +2056,7 @@ unittest
 
         override void check ()
         {
-            auto node = new RemoteAPI!API(node_tid);
+            auto node = new RemoteAPI!API(node_chn);
 
             // We need to return immediately so that the main thread can continue testing
             runTask(() {
@@ -1939,7 +2068,7 @@ unittest
 
     auto node_1 = RemoteAPI!API.spawn!Node();
     auto node_2 = RemoteAPI!API.spawn!Node();
-    node_tid = node_2.tid;
+    node_chn = node_2.chn();
     node_1.check();
     node_2.ctrl.shutdown();  // shut it down before wake-up, segfault() command will be ignored
     node_1.ctrl.shutdown();
@@ -2017,8 +2146,8 @@ unittest
         public void call2 ();
     }
 
-    __gshared C.Tid node1Addr;
-    __gshared C.Tid node2Addr;
+    __gshared BindChn node1Chn;
+    __gshared BindChn node2Chn;
 
     static class Node : API
     {
@@ -2028,8 +2157,8 @@ unittest
         // Main -> Node 1
         public override void call0 ()
         {
-            this.self = new RemoteAPI!API(node1Addr);
-            scope node2 = new RemoteAPI!API(node2Addr);
+            this.self = new RemoteAPI!API(node1Chn);
+            scope node2 = new RemoteAPI!API(node2Chn);
             node2.call1();
             assert(0, "This should never return as call2 shutdown this node");
         }
@@ -2038,10 +2167,10 @@ unittest
         public override void call1 ()
         {
             assert(this.self is null);
-            scope node1 = new RemoteAPI!API(node1Addr);
+            scope node1 = new RemoteAPI!API(node1Chn);
             node1.call2();
             // Make really sure Node 1 is dead
-            while (!node1Addr.mbox.isClosed())
+            while (!node1.chn().isClosed())
                 sleep(100.msecs);
         }
 
@@ -2056,8 +2185,8 @@ unittest
     // Long timeout to ensure we don't spuriously pass
     auto node1 = RemoteAPI!API.spawn!Node(500.msecs);
     auto node2 = RemoteAPI!API.spawn!Node();
-    node1Addr = node1.ctrl.tid();
-    node2Addr = node2.ctrl.tid();
+    node1Chn = node1.ctrl.chn();
+    node2Chn = node2.ctrl.chn();
 
     // This will timeout (because the node will be gone)
     // However if something is wrong, either `joinall` will never return,
@@ -2187,7 +2316,7 @@ unittest
         public void call1 ();
     }
 
-    __gshared C.Tid node2Addr;
+    __gshared BindChn node2Chn;
     static shared bool done;
 
     static class Node : API
@@ -2196,7 +2325,7 @@ unittest
 
         public override void call0 ()
         {
-            scope node2 = new RemoteAPI!API(node2Addr);
+            scope node2 = new RemoteAPI!API(node2Chn);
             node2.call1();
         }
 
@@ -2209,7 +2338,7 @@ unittest
 
     auto node1 = RemoteAPI!API.spawn!Node(500.msecs);
     auto node2 = RemoteAPI!API.spawn!Node();
-    node2Addr = node2.ctrl.tid();
+    node2Chn = node2.ctrl.chn();
     node2.ctrl.sleep(2.seconds, false);
 
     try
@@ -2299,7 +2428,7 @@ unittest
     }
 
     auto node = RemoteAPI!BaseAPI.spawn!BaseNode();
-    scope extnode = new RemoteAPI!APIExtended(node.ctrl.tid());
+    scope extnode = new RemoteAPI!APIExtended(node.ctrl.chn());
     assert(extnode.required() == 42);
     assertThrown!ClientException(extnode.optional());
     node.ctrl.shutdown();

--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -41,6 +41,7 @@ public import std.variant;
 import core.atomic;
 import core.sync.condition;
 import core.sync.mutex;
+import core.sync.semaphore;
 import core.thread;
 import core.time : MonoTime;
 import std.range.primitives;
@@ -48,6 +49,7 @@ import std.traits;
 import std.algorithm;
 import std.typecons;
 import std.container : DList;
+import std.exception : assumeWontThrow;
 
 import geod24.RingBuffer;
 
@@ -251,6 +253,14 @@ class TidMissingException : Exception
     import std.exception : basicExceptionCtors;
     ///
     mixin basicExceptionCtors;
+}
+
+class FiberBlockedException : Exception
+{
+    this(string msg = "Fiber is blocked") @safe pure nothrow @nogc
+    {
+        super(msg);
+    }
 }
 
 // Thread ID
@@ -860,15 +870,22 @@ public void thisScheduler (FiberScheduler value) nothrow
  */
 class FiberScheduler
 {
+    /// Default ctor
+    this () nothrow
+    {
+        this.sem = assumeWontThrow(new Semaphore());
+        this.blocked_ex = new FiberBlockedException();
+    }
+
     /**
      * This creates a new Fiber for the supplied op and then starts the
      * dispatcher.
      */
     void start(void delegate() op)
     {
-        create(op);
+        create(op, true);
         // Make sure the just-created fiber is run first
-        dispatch(this.m_fibers.length - 1);
+        dispatch();
     }
 
     /**
@@ -913,6 +930,19 @@ class FiberScheduler
     }
 
     /**
+     * If the caller is a scheduled Fiber, this yields execution to another
+     * scheduled Fiber.
+     */
+    static void yieldAndThrow(Throwable t) nothrow
+    {
+        // NOTE: It's possible that we should test whether the calling Fiber
+        //       is an InfoFiber before yielding, but I think it's reasonable
+        //       that any fiber should yield here.
+        if (Fiber.getThis())
+            Fiber.yieldAndThrow(t);
+    }
+
+    /**
      * Returns an appropriate ThreadInfo instance.
      *
      * Returns a ThreadInfo instance specific to the calling Fiber if the
@@ -940,8 +970,10 @@ protected:
      *
      * Params:
      *   op = The delegate the fiber should call
+     *   insert_front = Fiber will be added to the front
+     *                  of the ready queue to be run first
      */
-    void create (void delegate() op) nothrow
+    void create (void delegate() op, bool insert_front = false) nothrow
     {
         void wrap()
         {
@@ -952,7 +984,10 @@ protected:
             op();
         }
 
-        m_fibers ~= new InfoFiber(&wrap);
+        if (insert_front)
+            this.readyq.insertFront(new InfoFiber(&wrap));
+        else
+            this.readyq.insertBack(new InfoFiber(&wrap));
     }
 
     /**
@@ -963,7 +998,7 @@ protected:
         ThreadInfo info;
 
         /// Semaphore reference that this Fiber is blocked on
-        FiberBinarySemaphore sem;
+        FiberBlocker blocker;
 
         this (void delegate() op, size_t sz = 512 * 1024) nothrow
         {
@@ -971,29 +1006,29 @@ protected:
         }
     }
 
-    final public class FiberBinarySemaphore
+    final public class FiberBlocker
     {
 
         /***********************************************************************
 
-            Associate `FiberBinarySemaphore` with the running `Fiber`
+            Associate `FiberBlocker` with the running `Fiber`
 
             `FiberScheduler` will check to see if the `Fiber` is blocking on a
-            `FiberBinarySemaphore` to avoid rescheduling it unnecessarily
+            `FiberBlocker` to avoid rescheduling it unnecessarily
 
         ***********************************************************************/
 
         private void registerToInfoFiber (InfoFiber info_fiber = cast(InfoFiber) Fiber.getThis()) nothrow
         {
             assert(info_fiber !is null, "This Fiber does not belong to FiberScheduler");
-            assert(info_fiber.sem is null, "This Fiber already has a registered FiberBinarySemaphore");
-            info_fiber.sem = this;
+            assert(info_fiber.blocker is null, "This Fiber already has a registered FiberBlocker");
+            info_fiber.blocker = this;
 
         }
 
         /***********************************************************************
 
-            Wait on the semaphore with optional timeout
+            Wait on the blocker with optional timeout
 
             Params:
                 period = Timeout period
@@ -1002,11 +1037,14 @@ protected:
 
         bool wait (Duration period = Duration.init) nothrow
         {
-            this.registerToInfoFiber();
             if (period != Duration.init)
                 this.limit = MonoTime.currTime + period;
 
-            FiberScheduler.yield();
+            if (this.shouldBlock())
+            {
+                this.registerToInfoFiber();
+                FiberScheduler.yieldAndThrow(this.outer.blocked_ex);
+            }
 
             this.limit = MonoTime.init;
             this.notified = false;
@@ -1015,7 +1053,7 @@ protected:
 
         /***********************************************************************
 
-            Unblock the Fiber waiting on this semaphore
+            Unblock the Fiber waiting on this blocker
 
         ***********************************************************************/
 
@@ -1023,13 +1061,14 @@ protected:
         {
             this.stopTimer();
             this.notified = true;
+            assumeWontThrow(this.outer.sem.notify());
         }
 
         /***********************************************************************
 
-            Query if `FiberBinarySemaphore` should still block
+            Query if `FiberBlocker` should still block
 
-            FiberBinarySemaphore will block the Fiber until it is notified or
+            FiberBlocker will block the Fiber until it is notified or
             the specified timeout is reached.
 
         ***********************************************************************/
@@ -1083,7 +1122,7 @@ protected:
         /// Time limit that will eventually unblock the caller if a timeout is specified
         MonoTime limit = MonoTime.init;
 
-        /// State of the semaphore
+        /// State of the blocker
         bool notified;
 
         /// State of the internal timer
@@ -1096,59 +1135,127 @@ private:
 
         Start the scheduling loop
 
-        Param:
-            pos = m_fibers index of the Fiber to execute first
-
     ***********************************************************************/
 
-    void dispatch(size_t pos = 0)
+    void dispatch ()
     {
-        import std.algorithm.mutation : remove;
-
         thisScheduler(this);
         scope (exit) thisScheduler(null);
 
-        assert(pos < m_fibers.length);
-        while (m_fibers.length > 0)
+        MonoTime earliest_timeout;
+
+        while (!this.readyq.empty() || !this.wait_list.empty())
         {
-            // Is Fiber waiting on a FiberBinarySemaphore?
-            if (auto sem = m_fibers[pos].sem)
+            while (!readyq.empty())
             {
-                // Is condition met?
-                // TRUE: Clear the sem and schedule the fiber
-                // FALSE: Skip it
-                if (sem.shouldBlock())
+                InfoFiber cur_fiber = this.readyq.front();
+                this.readyq.removeFront();
+
+                assert(cur_fiber.state != Fiber.State.TERM);
+
+                auto t = cur_fiber.call(Fiber.Rethrow.no);
+
+                // Fibers that block on a FiberBlocker throw an
+                // exception for scheduler to catch
+                if (t is this.blocked_ex)
                 {
-                    if (pos++ >= m_fibers.length - 1)
-                        pos = 0;
+                    auto cur_timeout = cur_fiber.blocker.getTimeout();
+
+                    // Keep track of the earliest timeout in the system
+                    if (cur_timeout != MonoTime.init
+                            && (earliest_timeout == MonoTime.init || cur_timeout < earliest_timeout))
+                    {
+                        earliest_timeout = cur_timeout;
+                    }
+
+                    this.wait_list.insert(cur_fiber);
                     continue;
                 }
-                else
+                else if (t)
+                    throw t;
+
+                if (cur_fiber.state != Fiber.State.TERM)
                 {
-                    m_fibers[pos].sem = null;
+                    this.readyq.insert(cur_fiber);
                 }
+
+                // See if there are Fibers to be woken up if we reach a timeout
+                // or the scheduler semaphore was notified
+                if (MonoTime.currTime >= earliest_timeout || this.sem.tryWait())
+                    earliest_timeout = wakeFibers();
             }
 
-            auto t = m_fibers[pos].call(Fiber.Rethrow.no);
-            if (t !is null)
+            if (!this.wait_list.empty())
             {
-                throw t;
+                Duration time_to_timeout = earliest_timeout - MonoTime.currTime;
+
+                // Sleep until a timeout or an event
+                if (earliest_timeout == MonoTime.init)
+                    this.sem.wait();
+                else if (time_to_timeout > 0.seconds)
+                    this.sem.wait(time_to_timeout);
             }
-            if (m_fibers[pos].state == Fiber.State.TERM)
-            {
-                if (pos >= (m_fibers = remove(m_fibers, pos)).length)
-                    pos = 0;
-            }
-            else if (pos++ >= m_fibers.length - 1)
-            {
-                pos = 0;
-            }
+
+            // OS Thread woke up populate ready queue
+            earliest_timeout = wakeFibers();
         }
     }
 
+    /***********************************************************************
+
+        Move unblocked Fibers to ready queue
+
+        Return:
+            Returns the earliest timeout left in the waiting list
+
+    ***********************************************************************/
+
+    MonoTime wakeFibers()
+    {
+        import std.range;
+        MonoTime earliest_timeout;
+
+        auto wait_range = this.wait_list[];
+        while (!wait_range.empty)
+        {
+            auto fiber = wait_range.front;
+
+            // Remove the unblocked Fiber from wait list and
+            // append it to the end ofready queue
+            if (!fiber.blocker.shouldBlock())
+            {
+                this.wait_list.popFirstOf(wait_range);
+                fiber.blocker = null;
+                this.readyq.insert(fiber);
+            }
+            else
+            {
+                auto timeout = fiber.blocker.getTimeout();
+                if (timeout != MonoTime.init
+                        && (earliest_timeout == MonoTime.init || timeout < earliest_timeout))
+                {
+                    earliest_timeout = timeout;
+                }
+                wait_range.popFront();
+            }
+        }
+
+        return earliest_timeout;
+    }
+
 private:
-    /// List of `InfoFiber`s currently in the system
-    InfoFiber[] m_fibers;
+
+    /// OS semaphore for scheduler to sleep on
+    Semaphore sem;
+
+    /// A FIFO Queue of Fibers ready to run
+    DList!InfoFiber readyq;
+
+    /// List of Fibers waiting for an event
+    DList!InfoFiber wait_list;
+
+    /// Cached instance of FiberBlockedException
+    FiberBlockedException blocked_ex;
 }
 
 /// Ensure argument to `start` is run first
@@ -1612,7 +1719,7 @@ public alias SelectReturn = Tuple!(bool, "success", int, "id");
 
 ***********************************************************************/
 
-public SelectReturn select (ref SelectEntry[] read_list, ref SelectEntry[] write_list)
+public SelectReturn select (ref SelectEntry[] read_list, ref SelectEntry[] write_list, Duration timeout = Duration.init)
 {
     import std.random : randomShuffle;
 
@@ -1632,7 +1739,8 @@ public SelectReturn select (ref SelectEntry[] read_list, ref SelectEntry[] write
         entry.selectable.selectWrite(entry.select_data, ss, sel_id++);
     }
 
-    ss.sem.wait();
+    if (!ss.blocker.wait(timeout))
+        return SelectReturn(false, -1); // Timed out
 
     return SelectReturn(ss.success, ss.id);
 }
@@ -1647,8 +1755,8 @@ public SelectReturn select (ref SelectEntry[] read_list, ref SelectEntry[] write
 
 final private class SelectState
 {
-    /// Shared semaphore object for multiple ChannelQueueEntry objects
-    FiberScheduler.FiberBinarySemaphore sem;
+    /// Shared blocker object for multiple ChannelQueueEntry objects
+    FiberScheduler.FiberBlocker blocker;
 
     /***********************************************************************
 
@@ -1658,7 +1766,7 @@ final private class SelectState
 
     this () nothrow
     {
-        this.sem = thisScheduler().new FiberBinarySemaphore();
+        this.blocker = thisScheduler().new FiberBlocker();
     }
 
     /***********************************************************************
@@ -1788,7 +1896,7 @@ final public class Channel (T) : Selectable
         {
             ChannelQueueEntry q_ent = this.enqueueEntry(this.writeq, &val);
             this.lock.unlock_nothrow();
-            return q_ent.sem.wait(duration) && q_ent.success;
+            return q_ent.blocker.wait(duration) && q_ent.success;
         }
 
         this.lock.unlock_nothrow();
@@ -1827,7 +1935,7 @@ final public class Channel (T) : Selectable
         if (ChannelQueueEntry readq_ent = this.dequeueEntry(this.readq, caller_sel, caller_sel_id))
         {
             *readq_ent.pVal = val;
-            readq_ent.sem.notify();
+            readq_ent.blocker.notify();
             return true;
         }
 
@@ -1870,7 +1978,7 @@ final public class Channel (T) : Selectable
         if (success || this.closed || sel_state.id == -1)
         {
             this.lock.unlock_nothrow();
-            sel_state.sem.notify();
+            sel_state.blocker.notify();
         }
         else
             this.lock.unlock_nothrow();
@@ -1919,7 +2027,7 @@ final public class Channel (T) : Selectable
         {
             ChannelQueueEntry q_ent = this.enqueueEntry(this.readq, &output);
             this.lock.unlock_nothrow();
-            return q_ent.sem.wait(duration) && q_ent.success;
+            return q_ent.blocker.wait(duration) && q_ent.success;
         }
 
         this.lock.unlock_nothrow();
@@ -1982,7 +2090,7 @@ final public class Channel (T) : Selectable
         }
 
         if (write_ent)
-            write_ent.sem.notify();
+            write_ent.blocker.notify();
         return true;
     }
 
@@ -2014,7 +2122,7 @@ final public class Channel (T) : Selectable
         if (success || this.closed || sel_state.id == -1)
         {
             this.lock.unlock_nothrow();
-            sel_state.sem.notify();
+            sel_state.blocker.notify();
         }
         else
             this.lock.unlock_nothrow();
@@ -2087,8 +2195,8 @@ final public class Channel (T) : Selectable
 
     private class ChannelQueueEntry
     {
-        /// Semaphore blocking the `Fiber`
-        FiberScheduler.FiberBinarySemaphore sem;
+        /// FiberBlocker blocking the `Fiber`
+        FiberScheduler.FiberBlocker blocker;
 
         /// Pointer to the variable that we will read to/from
         T* pVal;
@@ -2109,9 +2217,9 @@ final public class Channel (T) : Selectable
             this.sel_id = sel_id;
 
             if (this.select_state)
-                this.sem = this.select_state.sem;
+                this.blocker = this.select_state.blocker;
             else
-                this.sem = thisScheduler().new FiberBinarySemaphore();
+                this.blocker = thisScheduler().new FiberBlocker();
         }
 
         /***********************************************************************
@@ -2128,7 +2236,7 @@ final public class Channel (T) : Selectable
         {
             this.success = false;
             if (!this.select_state || this.select_state.tryConsume(this.sel_id, this.success))
-                this.sem.notify();
+                this.blocker.notify();
         }
     }
 
@@ -2193,7 +2301,7 @@ final public class Channel (T) : Selectable
             ChannelQueueEntry qent = entryq.front();
             auto peer_sel = qent.select_state;
 
-            if ((!peer_sel || !peer_sel.isConsumed()) && qent.sem.shouldBlock())
+            if ((!peer_sel || !peer_sel.isConsumed()) && qent.blocker.shouldBlock())
             {
                 // If we are in a select call, try to consume the caller select
                 // if we can't consume the caller select, no need to continue
@@ -2206,7 +2314,7 @@ final public class Channel (T) : Selectable
                 // Try to consume the peer select if it exists
                 // If peer_sel was consumed by someone else, tough luck
                 // In that case, whole select will fail since we consumed the caller_sel
-                if ((!peer_sel || peer_sel.tryConsume(qent.sel_id)) && qent.sem.stopTimer())
+                if ((!peer_sel || peer_sel.tryConsume(qent.sel_id)) && qent.blocker.stopTimer())
                 {
                     entryq.removeFront();
                     return qent;


### PR DESCRIPTION
Resources held by the Fibers should be tracked and accounted for when FiberScheduler is exiting.

Depends on #100 
Depends on #99  