### PR TITLE
Strongly type and differentiate the listening connection to the remote node

### DIFF
--- a/source/geod24/concurrency.d
+++ b/source/geod24/concurrency.d
@@ -2672,13 +2672,13 @@ public:
     FiberScheduler scheduler = new FiberScheduler;
     auto chn1 = new Channel!int();
 
-    immutable auto start = MonoTime.currTime;
+    auto start = MonoTime.currTime;
 
     auto t1 = new Thread({
         FiberScheduler scheduler = new FiberScheduler;
         scheduler.start(
             () {
-                Thread.sleep(100.msecs);
+                Thread.sleep(1000.msecs);
                 assert(chn1.write(42));
             }
         );
@@ -2690,7 +2690,7 @@ public:
         scheduler.start(
             () {
                 int read_val;
-                Thread.sleep(200.msecs);
+                Thread.sleep(2000.msecs);
                 assert(chn1.read(read_val));
                 assert(read_val == 43);
             }
@@ -2702,16 +2702,20 @@ public:
         () {
             int read_val;
 
+            scope (failure) chn1.close();
+
             assert(!chn1.read(read_val, 10.msecs));
             assert(MonoTime.currTime - start >= 10.msecs);
-            assert(chn1.read(read_val, 200.msecs));
-            assert(MonoTime.currTime - start >= 100.msecs);
+            assert(chn1.read(read_val, 1500.msecs));
+            assert(MonoTime.currTime - start >= 1000.msecs);
             assert(read_val == 42);
 
+            start = MonoTime.currTime;
+
             assert(!chn1.write(read_val + 1, 10.msecs));
-            assert(MonoTime.currTime - start >= 110.msecs);
-            assert(chn1.write(read_val + 1, 200.msecs));
-            assert(MonoTime.currTime - start >= 200.msecs);
+            assert(MonoTime.currTime - start >= 10.msecs);
+            assert(chn1.write(read_val + 1, 1000.msecs));
+            assert(MonoTime.currTime - start >= 510.msecs);
         }
     );
 


### PR DESCRIPTION
```
Since our framework follow the same model as the basic TCP/IP server,
we have two kinds of connections: the "main" connection, or listener,
which in C would be the file descriptor given by `bind(2)`.
Whenever a client wants to connect to us, they reach us through that
connection, and we establish a new client connection.
In C, that would be the file descriptor returned by `accept`,
in our framework it is a `RemoteAPI`.
```

@omerfirmak : Hope the changes here make sense. I did adapt your PR to be fully typed, in light of those, but it still times out.