### PR TITLE
Use fetch-depth:2 to let codecov detect the sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Requiried for codecov action
+        fetch-depth: 2
     - uses: dlang-community/setup-dlang@v1
 
     - name: 'Build & Test'


### PR DESCRIPTION
We see a warning in PR workflows otherwise.