### PR TITLE
Fix blocking in Ctor edge case

### DIFF
--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -440,7 +440,7 @@ private bool isMainThread () @trusted nothrow
     // we are in the main thread
     if (scheduler is null)
         scheduler = new C.FiberScheduler;
-    return C.thisScheduler() is null;
+    return Fiber.getThis() is null;
 }
 
 /*******************************************************************************
@@ -463,7 +463,7 @@ private bool isMainThread () @trusted nothrow
 
 public void runTask (void delegate() dg) nothrow
 {
-    assert(!isMainThread(), "Cannot call this function from the main thread");
+    assert(scheduler !is null, "Cannot call this delegate from the main thread");
     scheduler.spawn(dg);
 }
 


### PR DESCRIPTION
Since #116, to allow starting tasks in Ctor of nodes,
LocalRest registers the FiberScheduler before starting
the dispatch loop. This might cause the main thread to try
blocking on Fiber level primitives, which is not possible.

isMainThread() should check for a Fiber context rather than
a running FiberScheduler instance and runTask() should be happy
with a scheduler instance even if it is running in the main thread.