### PR TITLE
Flush stdout before abort()

### DIFF
--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -879,6 +879,7 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
 
             try writeln("Full error: ", t);
             catch (Exception e) { /* Nothing more we can do at this point */ }
+            fflush(core.stdc.stdio.stdout);
             abort();
         }
     }


### PR DESCRIPTION
Both `writeln` and `printf` should be flushing the output
(as that happens when a `\n` is encountered), but for some reasons,
we don't see it in Github CI.