### PR TITLE
Inform peer about the assertion inside API

### DIFF
--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -742,7 +742,7 @@ public final class RemoteAPI (API, alias S = VibeJSONSerializer!()) : API
                                 node.%1$s(args.args);
                             res.status = Status.Success;
                         }
-                        catch (Exception e)
+                        catch (Throwable e)
                         {
                             res.status = Status.ClientFailed;
                             res.data = SerializedData(e.toString());


### PR DESCRIPTION
Towards https://github.com/bosagora/agora/issues/1974

Previously when an assertion happened inside an API call, whole process is aborted. Instead peer node can be informed about the situation. An assertion inside a node shouldn't have fatal affects (like `abort`) on other nodes (considering Vibe.d like approach). This change will allow us to achieve the requirement in the mentioned issue. This will also change how a test will log when assertion happens inside API;

- Assertion failure will be logged (previously this was there)
- Network nodes' `printLog` will be initiated (if `scope(failure)` in tests)
- Stack trace of the asserting node will be logged (previously this was there)
- Stack trace of the main thread will be logged

_Lines starting with `#` will not be included in the actual output_

```
---------------------------- START OF LOGS ----------------------------
source/agora/test/ValidatorRecurringEnrollment.d(35): Node logs:

Log for node: validator-0.boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8.localrest
======================================================================
...
2022-01-07 11:40:00,983 Info [agora.node.Registry] - Registry is caching DNS server for zone '{ value: "flash.coinnet.bosagora.io." }'
2022-01-07 11:40:01,49 Info [agora.network.Manager] - Doing periodic network discovery: 5 required peers requested, 5 missing, known 6
2022-01-07 11:40:01,49 Info [agora.consensus.protocol.Nominator] - Starting nominating timer..
2022-01-07 11:40:01,51 Info [agora.network.Client.boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8] - Peer identity established
2022-01-07 11:40:01,51 Info [agora.common.BanManager] - BanManager: Address http://validator-0.boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8.localrest/ banned until 1609459500
...
0x94b78736ae8ddf97f05a30e549f5eab377648a9116f3033ab7dcb8c9528ee717fd8d94dae7fe3ecc9d43290204ca2a41f710e798a3446b553c7a415d968e7177, key: boa1xzval4nvru2ej9m0rptq7hatukkavemryvct4f8smyy3ky9ct5u0s8w6gfy)
2022-01-07 11:40:01,52 Info [agora.node.Registry] - Registering addresses TYPE.CNAME: [http://validator-1.boa1xzval3ah8z7ewhuzx6mywveyr79f24w49rdypwgurhjkr8z2ke2mycftv9n.localrest/] for public key: boa1xzval3ah8z7ewhuzx6mywveyr79f24w49rdypwgurhjkr8z2ke2mycftv9n
2022-01-07 11:40:01,53 Info [agora.network.Client.boa1xrval5rzmma29zh4aqgv3mvcarhwa0w8rgthy3l9vaj3fywf9894ycmjkm8] - Peer identity established
...
======================================================================

Module tests failed: agora.test.ValidatorRecurringEnrollment
geod24.LocalRest.ClientException@submodules/localrest/source/geod24/LocalRest.d-mixin-1220(1239): Request to const(Block)[] geod24.LocalRest.RemoteAPI!(TestAPI, Serializer).RemoteAPI.getBlocksFrom(ulong _param_0, uint _param_1) @safe couldn't be processed : core.exception.AssertError@source/agora/node/FullNode.d(1034): hello world
#
# ## LOGS of asserted node
----------------
source/agora/test/Base.d:172 nothrow void agora.test.Base.testAssertHandler(immutable(char)[], ulong, immutable(char)[]) [0x56443349d31c]
core/exception.d:601 onAssertErrorMsg [0x564434143361]
core/exception.d:795 _d_assert_msg [0x5644341438a5]
source/agora/node/FullNode.d:1034 @safe const(agora.consensus.data.Block.Block)[] agora.node.FullNode.FullNode.getBlocksFrom(ulong, uint) [0x5644334338f7]
submodules/localrest/source/geod24/LocalRest.d-mixin-727:742 void geod24.LocalRest.RemoteAPI!(agora.test.Base.TestAPI, agora.test.Base.Serializer).RemoteAPI.handleCommand(geod24.LocalRest.Command, agora.test.Base.TestAPI, geod24.LocalRest.FilterAPI, geod24.concurrency.Channel!(geod24.LocalRest.Response).Channel) [0x5644334a946d]
submodules/localrest/source/geod24/LocalRest.d:867 void geod24.LocalRest.RemoteAPI!(agora.test.Base.TestAPI, agora.test.Base.Serializer).RemoteAPI.spawned!(agora.test.Base.TestValidatorNode).spawned(geod24.concurrency.Channel!(geod24.LocalRest.Connection).Channel, immutable(char)[], int, agora.node.Config.Config, shared(geod24.Registry.AnyRegistry)*, immutable(agora.consensus.data.Block.Block)[], in ref agora.test.Base.TestConf, shared(ulong)*).runNode().__lambda4().__lambda14() [0x5644334cf5d1]
core/thread/context.d:46 void core.thread.context.Callable.opCall() [0x564434198a1c]
core/thread/fiber.d:1141 void core.thread.fiber.Fiber.run() [0x56443414aaf8]
core/thread/fiber.d:198 fiber_entryPoint [0x56443414aa35]
#
# ## LOGS of main test
----------------
submodules/localrest/source/geod24/LocalRest.d-mixin-1220:1239 @safe const(agora.consensus.data.Block.Block)[] geod24.LocalRest.RemoteAPI!(agora.test.Base.TestAPI, agora.test.Base.Serializer).RemoteAPI.getBlocksFrom(ulong, uint) [0x564433430edf]
source/agora/test/ValidatorRecurringEnrollment.d:42 void agora.test.ValidatorRecurringEnrollment.__unittest_L28_C1() [0x56443336eccf]
source/agora/test/ValidatorRecurringEnrollment.d [0x56443343d935]
source/agora/test/Base.d:296 bool agora.test.Base.customModuleUnitTester().runTest(agora.test.Base.customModuleUnitTester().ModTest) [0x56443349dd25]
source/agora/test/Base.d:351 void agora.test.Base.customModuleUnitTester().runInParallel(agora.test.Base.customModuleUnitTester().ModTest[]).WorkThread.run() [0x56443349e283]
core/thread/context.d:46 void core.thread.context.Callable.opCall() [0x564434198a1c]
core/thread/threadbase.d:429 void core.thread.threadbase.ThreadBase.run() [0x56443414e078]
core/thread/osthread.d:349 void core.thread.osthread.Thread.run() [0x56443414b864]
core/thread/osthread.d:2439 thread_entryPoint [0x56443414be1f]
??:? [0x7f918f8f1608]
??:? clone [0x7f918f6ae292]
```