### PR TITLE
Fix and improve the CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,17 @@
 name: CI
 
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - 'v*.*.x'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'v*.*.x'
+  # Do a periodic build (every Monday at 0600) to ensure integrity
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   build:
@@ -8,25 +19,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        dc: [ dmd-latest, ldc-latest, dmd-2.085.1, ldc-1.14.0 ]
+        include:
+            - { os: macos-latest,   dc: ldc-latest }
+            - { os: ubuntu-latest,  dc: dmd-latest }
+            - { os: ubuntu-latest,  dc: ldc-latest }
+            - { os: windows-latest, dc: dmd-latest }
+            - { os: windows-latest, dc: ldc-latest }
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         # Requiried for codecov action
         fetch-depth: 2
     - uses: dlang-community/setup-dlang@v1
+      with:
+          compiler: ${{ matrix.dc }}
 
     - name: 'Build & Test'
       shell: bash
       run: |
-        dub test --compiler=$DC -b unittest-cov
+        dub test -b unittest-cov
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         flags: unittests

--- a/source/geod24/LocalRest.d
+++ b/source/geod24/LocalRest.d
@@ -1676,7 +1676,7 @@ unittest
     assert(current2 - current1 < 200.msecs);
 
     // Make one of the node sleep
-    n1.sleep(1.seconds);
+    n1.sleep(1300.msecs);
     // Make sure our main thread is not suspended,
     // nor is the second node
     assert(2 == n2.call());


### PR DESCRIPTION
- Properly pass the compiler parameter to the Github action installing it;
- Improve job definitions;
- Set up a periodic build to avoid breakage when no development happens;
- Fix a Windows-only CI failure;